### PR TITLE
Feat/37 centralized error handling

### DIFF
--- a/iviss-backend/Cargo.lock
+++ b/iviss-backend/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "async-trait"
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1222,9 +1222,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -1940,9 +1940,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-normalization"
@@ -2355,18 +2355,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2435,6 +2435,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -3,46 +3,133 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use serde_json::json;
+use serde::Serialize;
 
-#[allow(dead_code)]
+#[derive(Serialize)]
+struct AppErrorResponse {
+    code: String,
+    message: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
+
     #[error("Authentication failed: {0}")]
-    Auth(String),
+    Unauthorized(String),
+
     #[error("Not found: {0}")]
     NotFound(String),
+
     #[error("Bad request: {0}")]
     BadRequest(String),
+
+    #[error("External API failure: {0}")]
+    ExternalApiFailure(String),
+
     #[error("Internal server error: {0}")]
     Internal(#[from] anyhow::Error),
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, message) = match &self {
-            AppError::Database(_) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Database Error".to_string(),
+        let (status, code, message) = match &self {
+            AppError::Database(err) => {
+                // Log the detailed error for the server operator
+                tracing::error!("Database error: {:?}", err);
+                // Return a generic error to the client
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "DATABASE_ERROR".to_string(),
+                    "Internal Server Error".to_string(),
+                )
+            }
+            AppError::Unauthorized(msg) => (
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED".to_string(),
+                msg.clone(),
             ),
-            AppError::Auth(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
-            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, "NOT_FOUND".to_string(), msg.clone())
+            }
+            AppError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                "BAD_REQUEST".to_string(),
+                msg.clone(),
+            ),
+            AppError::ExternalApiFailure(msg) => {
+                tracing::error!("External API failure: {}", msg);
+                (
+                    StatusCode::BAD_GATEWAY,
+                    "EXTERNAL_API_FAILURE".to_string(),
+                    "External Service Unavailable".to_string(),
+                )
+            }
             AppError::Internal(err) => {
                 tracing::error!("Internal error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
+                    "INTERNAL_ERROR".to_string(),
                     "Internal Server Error".to_string(),
                 )
             }
         };
 
-        let body = Json(json!({
-            "error": message
-        }));
+        let body = Json(AppErrorResponse { code, message });
 
         (status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+
+    // Helper to get response body as JSON
+    async fn get_body_json(response: Response) -> Value {
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body_bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_not_found_response() {
+        let err = AppError::NotFound("Resource missing".into());
+        let response = err.into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = get_body_json(response).await;
+        assert_eq!(body["code"], "NOT_FOUND");
+        assert_eq!(body["message"], "Resource missing");
+    }
+
+    #[tokio::test]
+    async fn test_unauthorized_response() {
+        let err = AppError::Unauthorized("Invalid token".into());
+        let response = err.into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let body = get_body_json(response).await;
+        assert_eq!(body["code"], "UNAUTHORIZED");
+        assert_eq!(body["message"], "Invalid token");
+    }
+
+    #[tokio::test]
+    async fn test_external_api_failure_response() {
+        let err = AppError::ExternalApiFailure("Timeout connecting to provider".into());
+        let response = err.into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        let body = get_body_json(response).await;
+        assert_eq!(body["code"], "EXTERNAL_API_FAILURE");
+        assert_eq!(body["message"], "External Service Unavailable");
     }
 }

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -5,12 +5,14 @@ use axum::{
 };
 use serde::Serialize;
 
+#[allow(dead_code)]
 #[derive(Serialize)]
 struct AppErrorResponse {
     code: String,
     message: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     #[error("Database error: {0}")]
@@ -32,6 +34,7 @@ pub enum AppError {
     Internal(#[from] anyhow::Error),
 }
 
+#[allow(dead_code)]
 impl AppError {
     pub fn database(err: impl Into<sqlx::Error>) -> Self {
         Self::Database(err.into())

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -87,16 +87,10 @@ impl IntoResponse for AppError {
                 ErrorCode::Unauthorized,
                 msg.clone(),
             ),
-            AppError::NotFound(msg) => (
-                StatusCode::NOT_FOUND,
-                ErrorCode::NotFound,
-                msg.clone(),
-            ),
-            AppError::BadRequest(msg) => (
-                StatusCode::BAD_REQUEST,
-                ErrorCode::BadRequest,
-                msg.clone(),
-            ),
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, ErrorCode::NotFound, msg.clone()),
+            AppError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, ErrorCode::BadRequest, msg.clone())
+            }
             AppError::ExternalApiFailure(msg) => {
                 tracing::error!("External API failure: {}", msg);
                 (

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -6,9 +6,21 @@ use axum::{
 use serde::Serialize;
 
 #[allow(dead_code)]
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    DatabaseError,
+    Unauthorized,
+    NotFound,
+    BadRequest,
+    ExternalApiFailure,
+    InternalError,
+}
+
+#[allow(dead_code)]
 #[derive(Serialize)]
 struct AppErrorResponse {
-    code: String,
+    code: ErrorCode,
     message: String,
 }
 
@@ -66,28 +78,30 @@ impl IntoResponse for AppError {
                 // Return a generic error to the client
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    "DATABASE_ERROR".to_string(),
+                    ErrorCode::DatabaseError,
                     "Internal Server Error".to_string(),
                 )
             }
             AppError::Unauthorized(msg) => (
                 StatusCode::UNAUTHORIZED,
-                "UNAUTHORIZED".to_string(),
+                ErrorCode::Unauthorized,
                 msg.clone(),
             ),
-            AppError::NotFound(msg) => {
-                (StatusCode::NOT_FOUND, "NOT_FOUND".to_string(), msg.clone())
-            }
+            AppError::NotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                ErrorCode::NotFound,
+                msg.clone(),
+            ),
             AppError::BadRequest(msg) => (
                 StatusCode::BAD_REQUEST,
-                "BAD_REQUEST".to_string(),
+                ErrorCode::BadRequest,
                 msg.clone(),
             ),
             AppError::ExternalApiFailure(msg) => {
                 tracing::error!("External API failure: {}", msg);
                 (
                     StatusCode::BAD_GATEWAY,
-                    "EXTERNAL_API_FAILURE".to_string(),
+                    ErrorCode::ExternalApiFailure,
                     "External Service Unavailable".to_string(),
                 )
             }
@@ -95,7 +109,7 @@ impl IntoResponse for AppError {
                 tracing::error!("Internal error: {:?}", err);
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    "INTERNAL_ERROR".to_string(),
+                    ErrorCode::InternalError,
                     "Internal Server Error".to_string(),
                 )
             }

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -32,6 +32,28 @@ pub enum AppError {
     Internal(#[from] anyhow::Error),
 }
 
+impl AppError {
+    pub fn database(err: impl Into<sqlx::Error>) -> Self {
+        Self::Database(err.into())
+    }
+
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+
+    pub fn bad_request(msg: impl Into<String>) -> Self {
+        Self::BadRequest(msg.into())
+    }
+
+    pub fn unauthorized(msg: impl Into<String>) -> Self {
+        Self::Unauthorized(msg.into())
+    }
+
+    pub fn external_api_failure(msg: impl Into<String>) -> Self {
+        Self::ExternalApiFailure(msg.into())
+    }
+}
+
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code, message) = match &self {

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -110,8 +110,7 @@ impl IntoResponse for AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
+    use axum::http::StatusCode;
     use serde_json::Value;
 
     // Helper to get response body as JSON


### PR DESCRIPTION
### Refactored src/errors.rs:

  - It implements axum::response::IntoResponse for the AppError enum.
  - Defines variants for NotFound, DatabaseError, Unauthorized, and ExternalApiFailure .  
  - Ensure internal database errors are logged with full detail but returned to the client as a generic "Internal Server Error" for security .  
  - Supports JSON error bodies that include a machine-readable error code and a human-readable message.
closes issue #37
