### PR TITLE
Feat/79 ocr backend engine and recognition api

### DIFF
--- a/iviss-backend/Cargo.lock
+++ b/iviss-backend/Cargo.lock
@@ -30,6 +30,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,9 +55,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -51,16 +69,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "async-compression"
-version = "0.4.39"
+name = "arrayvec"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -76,7 +120,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -99,6 +143,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "axum"
@@ -165,7 +252,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -187,12 +274,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
+name = "bit_field"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
 ]
 
 [[package]]
@@ -205,16 +307,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "built"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -224,11 +344,13 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -245,10 +367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "compression-codecs"
-version = "0.4.36"
+name = "color_quant"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "compression-core",
  "flate2",
@@ -279,7 +407,7 @@ dependencies = [
  "async-trait",
  "convert_case",
  "json5",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -325,6 +453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +492,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -416,7 +572,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -439,7 +595,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -473,6 +629,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -511,6 +687,56 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -557,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -567,15 +793,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -595,27 +821,27 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -623,7 +849,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -662,6 +887,40 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -943,6 +1202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1229,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1278,17 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -992,6 +1308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,8 +1330,10 @@ dependencies = [
  "axum",
  "config",
  "dotenvy",
+ "image",
  "once_cell",
  "regex",
+ "rusty-tesseract",
  "serde",
  "serde_json",
  "sqlx",
@@ -1019,6 +1346,16 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1052,10 +1389,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.181"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -1085,6 +1444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1499,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -1186,6 +1570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,12 +1613,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1244,6 +1669,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1695,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1292,7 +1739,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1339,6 +1786,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -1391,7 +1850,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1444,6 +1903,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1937,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1508,6 +1990,49 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1639,6 +2164,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +2321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,7 +2392,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.115",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -1820,6 +2421,19 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1863,6 +2477,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-tesseract"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781e2d6ed8bb85607de972e6c174902953da1f682b1d43004f0e66bf419b798f"
+dependencies = [
+ "image",
+ "subprocess",
+ "substring",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2509,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1910,7 +2543,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2022,6 +2655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,7 +2768,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2149,7 +2791,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.115",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2281,6 +2923,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2324,7 +2985,20 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2353,7 +3027,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2364,7 +3038,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2374,6 +3048,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -2466,7 +3154,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2561,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -2667,7 +3355,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2741,9 +3429,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -2765,6 +3453,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2812,7 +3506,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.115",
+ "syn 2.0.117",
  "uuid",
 ]
 
@@ -2836,13 +3530,24 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -2899,6 +3604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,7 +3664,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2961,6 +3675,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3002,6 +3750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3766,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +3789,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3262,12 +4038,100 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml-rust2"
@@ -3299,7 +4163,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3320,7 +4184,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3340,7 +4204,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3380,7 +4244,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3404,3 +4268,42 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
+]

--- a/iviss-backend/Cargo.toml
+++ b/iviss-backend/Cargo.toml
@@ -24,4 +24,6 @@ time = "0.3.47"
 uuid = { version = "1.20.0", features = ["v4", "serde",]}
 regex = "1.12.3"
 once_cell = "1.21.3"
+rusty-tesseract = "1.1"
+image = "0.25"
 

--- a/iviss-backend/Dockerfile
+++ b/iviss-backend/Dockerfile
@@ -4,6 +4,14 @@
 # Development Stage - with cargo-watch for auto-reload
 FROM rust:latest AS development
 
+# Install Tesseract OCR CLI for the rusty-tesseract crate
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install cargo-watch for live reloading
 RUN cargo install cargo-watch
 
@@ -50,9 +58,13 @@ RUN cargo build --release
 # Runtime stage
 FROM debian:bookworm-slim AS production
 
-# Install runtime dependencies
+# Install runtime dependencies (PostgreSQL client + Tesseract OCR CLI)
 RUN apt-get update && \
-    apt-get install -y libpq5 ca-certificates && \
+    apt-get install -y --no-install-recommends \
+        libpq5 \
+        ca-certificates \
+        tesseract-ocr \
+        tesseract-ocr-eng && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/iviss-backend/src/api_doc.rs
+++ b/iviss-backend/src/api_doc.rs
@@ -8,6 +8,7 @@ use crate::dto::{
     create_control::*,
     list_control::*,
     pending_submission::*,
+    scan::*,
     search_vehicle::*,
     stats::DashboardStats,
     users::{UserProfile, UserRole},
@@ -45,6 +46,7 @@ impl Modify for SecurityAddon {
     tags(
         (name = "vehicles", description = "Vehicle lookup and image upload"),
         (name = "controls", description = "Roadside control tracking"),
+        (name = "scanning", description = "License plate OCR scanning"),
         (name = "stats", description = "Dashboard statistics"),
         (name = "users", description = "User profile management"),
         (name = "auth", description = "Authentication and registration"),
@@ -61,6 +63,7 @@ impl Modify for SecurityAddon {
         crate::handlers::auth::login,
         crate::handlers::auth::register,
         crate::handlers::auth::logout,
+        crate::handlers::scan::scan_plate,
     ),
 
     components(
@@ -99,6 +102,10 @@ impl Modify for SecurityAddon {
             DashboardStats,
             UserProfile,
             UserRole,
+            // ── scanning ──
+            ScanPlateResponse,
+            ScanResultData,
+            ScanErrorData,
             // ── auth ──
             crate::handlers::auth::LoginRequest,
             crate::handlers::auth::AuthResponse,

--- a/iviss-backend/src/dto/mod.rs
+++ b/iviss-backend/src/dto/mod.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod create_control;
 pub mod list_control;
 pub mod pending_submission;
+pub mod scan;
 pub mod search_vehicle;
 pub mod stats;
 pub mod users;

--- a/iviss-backend/src/dto/scan.rs
+++ b/iviss-backend/src/dto/scan.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Successful OCR scan result data.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ScanResultData {
+    /// Normalized plate text (uppercase, no spaces). Empty if nothing detected.
+    pub plate: String,
+    /// Raw text as returned by the OCR engine before normalization.
+    pub raw_text: String,
+    /// Tesseract confidence score (0.0 – 1.0).
+    pub confidence: f32,
+    /// Whether the normalized plate matches the Cameroon format (XX###XX).
+    pub format_valid: bool,
+}
+
+/// Error detail returned inside the scan response envelope.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ScanErrorData {
+    /// Machine-readable error code, e.g. `INVALID_IMAGE`.
+    pub code: String,
+    /// Human-readable error description.
+    pub message: String,
+}
+
+/// Envelope response for `POST /api/v1/scan/plate`.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ScanPlateResponse {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<ScanResultData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ScanErrorData>,
+}

--- a/iviss-backend/src/errors.rs
+++ b/iviss-backend/src/errors.rs
@@ -68,6 +68,10 @@ impl AppError {
     pub fn external_api_failure(msg: impl Into<String>) -> Self {
         Self::ExternalApiFailure(msg.into())
     }
+
+    pub fn internal_error(msg: impl Into<String>) -> Self {
+        Self::Internal(anyhow::anyhow!(msg.into()))
+    }
 }
 
 impl IntoResponse for AppError {

--- a/iviss-backend/src/handlers/mod.rs
+++ b/iviss-backend/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod list_control;
 pub mod pending_submission;
+pub mod scan;
 pub mod search_vehicle;
 pub mod stats;
 pub mod users;

--- a/iviss-backend/src/handlers/scan.rs
+++ b/iviss-backend/src/handlers/scan.rs
@@ -1,0 +1,149 @@
+use axum::{extract::Multipart, http::StatusCode, response::IntoResponse, Json};
+
+use crate::dto::scan::{ScanErrorData, ScanPlateResponse, ScanResultData};
+use crate::services::ocr_service;
+
+/// Maximum allowed image size: 5 MB.
+const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
+
+/// Allowed MIME types for the uploaded image.
+const ALLOWED_CONTENT_TYPES: &[&str] = &["image/jpeg", "image/png"];
+
+// ── POST /api/v1/scan/plate ──────────────────────────────────────────────────
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/scan/plate",
+    tag = "scanning",
+    operation_id = "scanPlate",
+    responses(
+        (status = 200, description = "OCR result (may have low confidence)", body = ScanPlateResponse),
+        (status = 400, description = "Invalid or missing image",            body = ScanPlateResponse),
+        (status = 415, description = "Unsupported media type",              body = ScanPlateResponse),
+        (status = 500, description = "Internal OCR error",                  body = ScanPlateResponse),
+    ),
+)]
+pub async fn scan_plate(mut multipart: Multipart) -> impl IntoResponse {
+    // ── 1. Extract the `image` field from the multipart body ─────────────────
+    let (content_type, image_bytes) = match extract_image_field(&mut multipart).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // ── 2. Validate content type ─────────────────────────────────────────────
+    if let Some(ref ct) = content_type {
+        if !ALLOWED_CONTENT_TYPES.iter().any(|a| ct.starts_with(a)) {
+            return error_response(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "UNSUPPORTED_MEDIA_TYPE",
+                "Only JPEG and PNG images are accepted",
+            );
+        }
+    }
+    // If no content_type header was sent with the field, we still try to
+    // decode it and let the image crate reject it if necessary.
+
+    // ── 3. Validate file size ────────────────────────────────────────────────
+    if image_bytes.len() > MAX_IMAGE_SIZE {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "INVALID_IMAGE",
+            "Image size exceeds 5 MB limit",
+        );
+    }
+
+    // ── 4. Run OCR pipeline ──────────────────────────────────────────────────
+    // Offload the CPU-heavy work to a blocking thread so we don't starve
+    // the async Tokio runtime.
+    let result = tokio::task::spawn_blocking(move || ocr_service::scan_plate(&image_bytes)).await;
+
+    match result {
+        Ok(Ok(scan_data)) => success_response(scan_data),
+        Ok(Err(app_err)) => {
+            tracing::warn!("OCR processing error: {app_err}");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OCR_ERROR",
+                "OCR processing failed",
+            )
+        }
+        Err(join_err) => {
+            tracing::error!("OCR task panicked: {join_err}");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OCR_ERROR",
+                "Internal Server Error",
+            )
+        }
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Walk the multipart stream to find a field named `image` and return its
+/// content-type and bytes. Returns an error response if the field is missing.
+async fn extract_image_field(
+    multipart: &mut Multipart,
+) -> Result<(Option<String>, Vec<u8>), (StatusCode, Json<ScanPlateResponse>)> {
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let name = field.name().unwrap_or_default().to_string();
+        if name != "image" {
+            continue;
+        }
+
+        let content_type = field.content_type().map(|s| s.to_string());
+        let bytes = field.bytes().await.map_err(|e| {
+            tracing::warn!("Failed to read multipart field: {e}");
+            error_response_tuple(
+                StatusCode::BAD_REQUEST,
+                "INVALID_IMAGE",
+                "Failed to read image data",
+            )
+        })?;
+
+        return Ok((content_type, bytes.to_vec()));
+    }
+
+    Err(error_response_tuple(
+        StatusCode::BAD_REQUEST,
+        "INVALID_IMAGE",
+        "Missing required field: image",
+    ))
+}
+
+fn success_response(data: ScanResultData) -> (StatusCode, Json<ScanPlateResponse>) {
+    (
+        StatusCode::OK,
+        Json(ScanPlateResponse {
+            success: true,
+            data: Some(data),
+            error: None,
+        }),
+    )
+}
+
+fn error_response(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+) -> (StatusCode, Json<ScanPlateResponse>) {
+    error_response_tuple(status, code, message)
+}
+
+fn error_response_tuple(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+) -> (StatusCode, Json<ScanPlateResponse>) {
+    (
+        status,
+        Json(ScanPlateResponse {
+            success: false,
+            data: None,
+            error: Some(ScanErrorData {
+                code: code.to_string(),
+                message: message.to_string(),
+            }),
+        }),
+    )
+}

--- a/iviss-backend/src/routes.rs
+++ b/iviss-backend/src/routes.rs
@@ -16,6 +16,7 @@ pub fn assembly(pool: DbPool) -> Router {
     let state = Arc::new(AppState::new(pool));
     Router::new()
         .route("/health", get(|| async { "OK" }))
+        .route("/api/v1/scan/plate", post(crate::handlers::scan::scan_plate))
         .route("/vehicles/search", post(search_vehicle))
         .route(
             "/controls",

--- a/iviss-backend/src/services/mod.rs
+++ b/iviss-backend/src/services/mod.rs
@@ -1,1 +1,2 @@
+pub mod ocr_service;
 pub mod vehicle_service;

--- a/iviss-backend/src/services/ocr_service.rs
+++ b/iviss-backend/src/services/ocr_service.rs
@@ -1,8 +1,9 @@
 use image::imageops::FilterType;
-use image::GenericImageView;
+use image::{GenericImageView, GrayImage, Luma};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rusty_tesseract::{Args, Image};
+use std::collections::HashMap;
 
 use crate::dto::scan::ScanResultData;
 use crate::errors::AppError;
@@ -14,17 +15,19 @@ static PLATE_REGEX: Lazy<Regex> =
 /// Target width (px) for the resized image fed to Tesseract.
 const TARGET_WIDTH: u32 = 800;
 
-/// Binarisation threshold (0–255). Pixels above this become white, below become black.
-const BINARY_THRESHOLD: u8 = 128;
+/// Radius (in pixels) for the adaptive threshold sliding window.
+const ADAPTIVE_RADIUS: u32 = 15;
+
+/// Offset subtracted from the local mean when applying adaptive threshold.
+const ADAPTIVE_C: i16 = 10;
 
 // ── public API ────────────────────────────────────────────────────────────────
 
 /// Run the full OCR pipeline on raw image bytes (JPEG / PNG).
 ///
-/// Pipeline: Load → Grayscale → Resize (800 px width) → Threshold → Tesseract.
-///
-/// Images are processed in-memory. `rusty-tesseract` writes a temp file
-/// internally for the Tesseract CLI call, which is cleaned up automatically.
+/// Pipeline:
+///   Load → Grayscale → Resize → Contrast stretch → Adaptive threshold
+///   → Tesseract (binary + inverted, PSM 7) → pick best result → normalise.
 pub fn scan_plate(image_bytes: &[u8]) -> Result<ScanResultData, AppError> {
     // 1. Load the image from raw bytes
     let img = image::load_from_memory(image_bytes)
@@ -33,103 +36,179 @@ pub fn scan_plate(image_bytes: &[u8]) -> Result<ScanResultData, AppError> {
     // 2. Convert to 8-bit grayscale
     let gray = img.to_luma8();
 
-    // 3. Resize – preserve aspect ratio, target width = 800 px
-    let (orig_w, _orig_h) = img.dimensions();
-    let gray = if orig_w > TARGET_WIDTH {
+    // 3. Resize – scale to target width (also upscales small images)
+    let (orig_w, _) = img.dimensions();
+    let gray = if orig_w != TARGET_WIDTH {
         let scale = TARGET_WIDTH as f32 / orig_w as f32;
-        let new_h = (img.height() as f32 * scale) as u32;
+        let new_h = (img.height() as f32 * scale).max(1.0) as u32;
         image::imageops::resize(&gray, TARGET_WIDTH, new_h, FilterType::Lanczos3)
     } else {
         gray
     };
 
-    // 4. Binarise (simple fixed threshold)
-    let binary = image::GrayImage::from_fn(gray.width(), gray.height(), |x, y| {
-        let px = gray.get_pixel(x, y);
-        if px[0] >= BINARY_THRESHOLD {
-            image::Luma([255u8])
-        } else {
-            image::Luma([0u8])
-        }
-    });
+    // 4. Contrast stretch (min-max normalisation to full 0–255 range)
+    let gray = contrast_stretch(&gray);
 
-    // 5. Convert back to DynamicImage for rusty-tesseract
-    let dynamic_img = image::DynamicImage::ImageLuma8(binary);
+    // 5. Adaptive threshold (handles uneven lighting / coloured backgrounds)
+    let binary = adaptive_threshold(&gray, ADAPTIVE_RADIUS, ADAPTIVE_C);
 
-    // 6. Create a rusty-tesseract Image from the DynamicImage
-    let tess_image = Image::from_dynamic_image(&dynamic_img)
-        .map_err(|e| AppError::internal_error(format!("Failed to create Tesseract image: {e}")))?;
+    // 6. Also produce an inverted version (handles dark text on light plates
+    //    vs light text on dark/coloured plates like orange Cameroon plates).
+    let inverted = invert_image(&binary);
 
-    // 7. Configure Tesseract arguments
+    // 7. Tesseract args — single text line (PSM 7), A-Z + 0-9 whitelist
     let args = Args {
         lang: "eng".to_string(),
-        config_variables: HashMap::from([
-            ("tessedit_char_whitelist".to_string(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".to_string()),
-        ]),
+        config_variables: HashMap::from([(
+            "tessedit_char_whitelist".to_string(),
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".to_string(),
+        )]),
         dpi: Some(300),
-        psm: Some(7), // Treat the image as a single text line
-        oem: Some(3), // Default OCR engine mode
+        psm: Some(7),
+        oem: Some(3),
     };
 
-    // 8. Run OCR
-    let raw_text = rusty_tesseract::image_to_string(&tess_image, &args)
-        .map_err(|e| AppError::internal_error(format!("Tesseract OCR failed: {e}")))?;
+    // 8. Run OCR on binary image
+    let result_binary = try_ocr(&binary, &args);
 
-    // rusty-tesseract doesn't expose per-word confidence via the simple API,
-    // so we use `image_to_data` to get word-level confidence scores.
-    let confidence = get_mean_confidence(&tess_image, &args);
+    // If the binary variant already matched the plate regex, return immediately
+    if let Some(ref r) = result_binary {
+        if r.format_valid {
+            return Ok(r.clone());
+        }
+    }
 
-    // 9. Normalise the extracted text
+    // 9. Run OCR on inverted image
+    let result_inverted = try_ocr(&inverted, &args);
+
+    if let Some(ref r) = result_inverted {
+        if r.format_valid {
+            return Ok(r.clone());
+        }
+    }
+
+    // 10. Neither matched — return whichever had more text / higher confidence
+    Ok(pick_best(result_binary, result_inverted))
+}
+
+// ── OCR helper ────────────────────────────────────────────────────────────────
+
+/// Attempt OCR on a single grayscale image. Returns None if Tesseract fails.
+fn try_ocr(img: &GrayImage, args: &Args) -> Option<ScanResultData> {
+    let dynamic_img = image::DynamicImage::ImageLuma8(img.clone());
+    let tess_image = Image::from_dynamic_image(&dynamic_img).ok()?;
+
+    let raw_text = rusty_tesseract::image_to_string(&tess_image, args).ok()?;
+    let confidence = get_mean_confidence(&tess_image, args);
     let normalised = normalise_plate(&raw_text);
-
-    // 10. Validate against Cameroon plate format
     let format_valid = PLATE_REGEX.is_match(&normalised);
 
-    Ok(ScanResultData {
-        plate: if format_valid {
-            normalised
-        } else {
-            String::new()
-        },
+    Some(ScanResultData {
+        plate: if format_valid { normalised } else { String::new() },
         raw_text: raw_text.trim().to_string(),
         confidence,
         format_valid,
     })
 }
 
-// ── helpers ───────────────────────────────────────────────────────────────────
+/// Pick the better of two optional OCR results.
+fn pick_best(a: Option<ScanResultData>, b: Option<ScanResultData>) -> ScanResultData {
+    let empty = ScanResultData {
+        plate: String::new(),
+        raw_text: String::new(),
+        confidence: 0.0,
+        format_valid: false,
+    };
 
-use std::collections::HashMap;
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            if a.format_valid { a }
+            else if b.format_valid { b }
+            else if a.confidence >= b.confidence && !a.raw_text.is_empty() { a }
+            else if !b.raw_text.is_empty() { b }
+            else { a }
+        }
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => empty,
+    }
+}
 
-/// Get mean confidence from Tesseract data output.
-/// Falls back to 0.0 if data extraction fails.
+// ── image processing helpers ──────────────────────────────────────────────────
+
+/// Min-max contrast stretch: maps the pixel range [min, max] → [0, 255].
+fn contrast_stretch(img: &GrayImage) -> GrayImage {
+    let mut min_val = 255u8;
+    let mut max_val = 0u8;
+    for px in img.pixels() {
+        min_val = min_val.min(px[0]);
+        max_val = max_val.max(px[0]);
+    }
+    if max_val == min_val {
+        return img.clone();
+    }
+    let range = (max_val - min_val) as f32;
+    GrayImage::from_fn(img.width(), img.height(), |x, y| {
+        let v = img.get_pixel(x, y)[0];
+        Luma([((v as f32 - min_val as f32) / range * 255.0) as u8])
+    })
+}
+
+/// Adaptive thresholding using a local mean (integral-image based, O(1) per pixel).
+fn adaptive_threshold(img: &GrayImage, radius: u32, c: i16) -> GrayImage {
+    let (w, h) = (img.width() as usize, img.height() as usize);
+    let iw = w + 1;
+
+    // Build integral image
+    let mut integral = vec![0i64; iw * (h + 1)];
+    for y in 0..h {
+        let mut row_sum = 0i64;
+        for x in 0..w {
+            row_sum += img.get_pixel(x as u32, y as u32)[0] as i64;
+            integral[(y + 1) * iw + (x + 1)] = row_sum + integral[y * iw + (x + 1)];
+        }
+    }
+
+    let r = radius as usize;
+    GrayImage::from_fn(img.width(), img.height(), |x, y| {
+        let (xi, yi) = (x as usize, y as usize);
+        let x1 = xi.saturating_sub(r);
+        let y1 = yi.saturating_sub(r);
+        let x2 = (xi + r + 1).min(w);
+        let y2 = (yi + r + 1).min(h);
+        let count = ((x2 - x1) * (y2 - y1)) as i64;
+        let sum = integral[y2 * iw + x2] - integral[y1 * iw + x2]
+            - integral[y2 * iw + x1] + integral[y1 * iw + x1];
+        let threshold = ((sum / count) as i16 - c).max(0) as u8;
+        if img.get_pixel(x, y)[0] > threshold { Luma([255u8]) } else { Luma([0u8]) }
+    })
+}
+
+/// Invert a grayscale image: 255 → 0, 0 → 255.
+fn invert_image(img: &GrayImage) -> GrayImage {
+    GrayImage::from_fn(img.width(), img.height(), |x, y| {
+        Luma([255 - img.get_pixel(x, y)[0]])
+    })
+}
+
+/// Get mean confidence from Tesseract data output. Falls back to 0.0.
 fn get_mean_confidence(image: &Image, args: &Args) -> f32 {
     match rusty_tesseract::image_to_data(image, args) {
         Ok(data) => {
-            let confidences: Vec<f32> = data
-                .data
-                .iter()
+            let confs: Vec<f32> = data.data.iter()
                 .filter(|d| d.conf > 0.0)
                 .map(|d| d.conf)
                 .collect();
-
-            if confidences.is_empty() {
-                0.0
-            } else {
-                let sum: f32 = confidences.iter().sum();
-                (sum / confidences.len() as f32 / 100.0).clamp(0.0, 1.0)
-            }
+            if confs.is_empty() { 0.0 }
+            else { (confs.iter().sum::<f32>() / confs.len() as f32 / 100.0).clamp(0.0, 1.0) }
         }
         Err(_) => 0.0,
     }
 }
 
-/// Uppercase, strip spaces / punctuation, keep only alphanumeric chars.
+/// Uppercase, strip non-alphanumeric chars.
 fn normalise_plate(raw: &str) -> String {
-    raw.to_uppercase()
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
-        .collect()
+    raw.to_uppercase().chars().filter(|c| c.is_ascii_alphanumeric()).collect()
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -154,10 +233,29 @@ mod tests {
 
     #[test]
     fn regex_rejects_invalid_plates() {
-        assert!(!PLATE_REGEX.is_match("C128BC"));   // only 1 leading letter
-        assert!(!PLATE_REGEX.is_match("CE12BC"));   // only 2 digits
-        assert!(!PLATE_REGEX.is_match("CE1234BC")); // 4 digits
-        assert!(!PLATE_REGEX.is_match("1E128BC"));  // starts with digit
+        assert!(!PLATE_REGEX.is_match("C128BC"));
+        assert!(!PLATE_REGEX.is_match("CE12BC"));
+        assert!(!PLATE_REGEX.is_match("CE1234BC"));
+        assert!(!PLATE_REGEX.is_match("1E128BC"));
         assert!(!PLATE_REGEX.is_match(""));
+    }
+
+    #[test]
+    fn contrast_stretch_full_range() {
+        let img = GrayImage::from_fn(3, 1, |x, _| {
+            Luma([match x { 0 => 100, 1 => 150, _ => 200 }])
+        });
+        let stretched = contrast_stretch(&img);
+        assert_eq!(stretched.get_pixel(0, 0)[0], 0);
+        assert_eq!(stretched.get_pixel(2, 0)[0], 255);
+    }
+
+    #[test]
+    fn adaptive_threshold_basic() {
+        let img = GrayImage::from_fn(5, 1, |x, _| {
+            Luma([if x == 2 { 200 } else { 10 }])
+        });
+        let result = adaptive_threshold(&img, 2, 5);
+        assert_eq!(result.get_pixel(2, 0)[0], 255);
     }
 }

--- a/iviss-backend/src/services/ocr_service.rs
+++ b/iviss-backend/src/services/ocr_service.rs
@@ -1,0 +1,163 @@
+use image::imageops::FilterType;
+use image::GenericImageView;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rusty_tesseract::{Args, Image};
+
+use crate::dto::scan::ScanResultData;
+use crate::errors::AppError;
+
+/// Cameroon plate format: 2 letters + 3 digits + 2 letters (e.g. CE128BC).
+static PLATE_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[A-Z]{2}[0-9]{3}[A-Z]{2}$").unwrap());
+
+/// Target width (px) for the resized image fed to Tesseract.
+const TARGET_WIDTH: u32 = 800;
+
+/// Binarisation threshold (0–255). Pixels above this become white, below become black.
+const BINARY_THRESHOLD: u8 = 128;
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Run the full OCR pipeline on raw image bytes (JPEG / PNG).
+///
+/// Pipeline: Load → Grayscale → Resize (800 px width) → Threshold → Tesseract.
+///
+/// Images are processed in-memory. `rusty-tesseract` writes a temp file
+/// internally for the Tesseract CLI call, which is cleaned up automatically.
+pub fn scan_plate(image_bytes: &[u8]) -> Result<ScanResultData, AppError> {
+    // 1. Load the image from raw bytes
+    let img = image::load_from_memory(image_bytes)
+        .map_err(|e| AppError::bad_request(format!("Cannot decode image: {e}")))?;
+
+    // 2. Convert to 8-bit grayscale
+    let gray = img.to_luma8();
+
+    // 3. Resize – preserve aspect ratio, target width = 800 px
+    let (orig_w, _orig_h) = img.dimensions();
+    let gray = if orig_w > TARGET_WIDTH {
+        let scale = TARGET_WIDTH as f32 / orig_w as f32;
+        let new_h = (img.height() as f32 * scale) as u32;
+        image::imageops::resize(&gray, TARGET_WIDTH, new_h, FilterType::Lanczos3)
+    } else {
+        gray
+    };
+
+    // 4. Binarise (simple fixed threshold)
+    let binary = image::GrayImage::from_fn(gray.width(), gray.height(), |x, y| {
+        let px = gray.get_pixel(x, y);
+        if px[0] >= BINARY_THRESHOLD {
+            image::Luma([255u8])
+        } else {
+            image::Luma([0u8])
+        }
+    });
+
+    // 5. Convert back to DynamicImage for rusty-tesseract
+    let dynamic_img = image::DynamicImage::ImageLuma8(binary);
+
+    // 6. Create a rusty-tesseract Image from the DynamicImage
+    let tess_image = Image::from_dynamic_image(&dynamic_img)
+        .map_err(|e| AppError::internal_error(format!("Failed to create Tesseract image: {e}")))?;
+
+    // 7. Configure Tesseract arguments
+    let args = Args {
+        lang: "eng".to_string(),
+        config_variables: HashMap::from([
+            ("tessedit_char_whitelist".to_string(), "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".to_string()),
+        ]),
+        dpi: Some(300),
+        psm: Some(7), // Treat the image as a single text line
+        oem: Some(3), // Default OCR engine mode
+    };
+
+    // 8. Run OCR
+    let raw_text = rusty_tesseract::image_to_string(&tess_image, &args)
+        .map_err(|e| AppError::internal_error(format!("Tesseract OCR failed: {e}")))?;
+
+    // rusty-tesseract doesn't expose per-word confidence via the simple API,
+    // so we use `image_to_data` to get word-level confidence scores.
+    let confidence = get_mean_confidence(&tess_image, &args);
+
+    // 9. Normalise the extracted text
+    let normalised = normalise_plate(&raw_text);
+
+    // 10. Validate against Cameroon plate format
+    let format_valid = PLATE_REGEX.is_match(&normalised);
+
+    Ok(ScanResultData {
+        plate: if format_valid {
+            normalised
+        } else {
+            String::new()
+        },
+        raw_text: raw_text.trim().to_string(),
+        confidence,
+        format_valid,
+    })
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+use std::collections::HashMap;
+
+/// Get mean confidence from Tesseract data output.
+/// Falls back to 0.0 if data extraction fails.
+fn get_mean_confidence(image: &Image, args: &Args) -> f32 {
+    match rusty_tesseract::image_to_data(image, args) {
+        Ok(data) => {
+            let confidences: Vec<f32> = data
+                .data
+                .iter()
+                .filter(|d| d.conf > 0.0)
+                .map(|d| d.conf)
+                .collect();
+
+            if confidences.is_empty() {
+                0.0
+            } else {
+                let sum: f32 = confidences.iter().sum();
+                (sum / confidences.len() as f32 / 100.0).clamp(0.0, 1.0)
+            }
+        }
+        Err(_) => 0.0,
+    }
+}
+
+/// Uppercase, strip spaces / punctuation, keep only alphanumeric chars.
+fn normalise_plate(raw: &str) -> String {
+    raw.to_uppercase()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect()
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalise_removes_spaces_and_dashes() {
+        assert_eq!(normalise_plate("ce 128 bc"), "CE128BC");
+        assert_eq!(normalise_plate("CE-128-BC"), "CE128BC");
+        assert_eq!(normalise_plate("  Ce128Bc  "), "CE128BC");
+    }
+
+    #[test]
+    fn regex_accepts_valid_plates() {
+        assert!(PLATE_REGEX.is_match("CE128BC"));
+        assert!(PLATE_REGEX.is_match("AB000CD"));
+        assert!(PLATE_REGEX.is_match("ZZ999ZZ"));
+    }
+
+    #[test]
+    fn regex_rejects_invalid_plates() {
+        assert!(!PLATE_REGEX.is_match("C128BC"));   // only 1 leading letter
+        assert!(!PLATE_REGEX.is_match("CE12BC"));   // only 2 digits
+        assert!(!PLATE_REGEX.is_match("CE1234BC")); // 4 digits
+        assert!(!PLATE_REGEX.is_match("1E128BC"));  // starts with digit
+        assert!(!PLATE_REGEX.is_match(""));
+    }
+}


### PR DESCRIPTION
### Summary
This PR implements the backend OCR engine for the IVISS scanning system using `rusty-tesseract` and the image crate. A new `POST /api/v1/scan/plate` endpoint accepts multipart image uploads, runs them through an image preprocessing and OCR pipeline, and returns structured JSON responses with the recognized plate text, confidence score, and format validation against the Cameroon plate standard (`XX###XX`).

### Key Features Implemented
- **Multipart Upload Endpoint**: Created `POST /api/v1/scan/plate` with full input validation — content-type checking (JPEG/PNG only), file size enforcement (5 MB limit), and proper error responses with structured codes (`INVALID_IMAGE`, `UNSUPPORTED_MEDIA_TYPE`, `OCR_ERROR`).

- **Image Preprocessing Pipeline**: Implemented a multi-step preprocessing chain — grayscale conversion, resolution normalization (800px target width), min-max contrast stretching, and adaptive thresholding using an integral-image based local mean for handling colored plates and uneven lighting.

- **Dual-Variant OCR Strategy**: The pipeline runs Tesseract on both the binarized image and its inverted version to handle both dark-on-light and light-on-dark plate styles (e.g. orange Cameroon plates), returning the first regex-matching result or the highest-confidence candidate.

- **Plate Format Validation**: Extracted text is normalized (uppercase, alphanumeric only) and validated against the Cameroon license plate regex (`^[A-Z]{2}[0-9]{3}[A-Z]{2}$`), with `format_valid` reported in the response.

- **Privacy-First Design**: All image processing is done in-memory with no persistent storage. Temporary files used internally by `rusty-tesseract` are automatically cleaned up.

- **Dockerfile & Dependency Updates**: Added tesseract-ocr and tesseract-ocr-eng to both development and production Docker stages. Switched from leptess (C FFI) to rusty-tesseract (CLI wrapper) to resolve compilation issues on Debian Bookworm.