### PR TITLE
BE-06 - Refresh Token with Device Signature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       EXTERNAL_DATABASE_URL: postgres://${EXTERNAL_POSTGRES_USER:-external_user}:${EXTERNAL_POSTGRES_PASSWORD:-external_password}@${EXTERNAL_POSTGRES_HOST:-localhost}:${EXTERNAL_POSTGRES_PORT:-5432}/${EXTERNAL_POSTGRES_DB:-external_db}
       REDIS_URL: redis://iviss-redis:6379
       JWT_SECRET: ${JWT_SECRET:-your_dev_jwt_secret_change_in_production}
+      ACTIVATION_CODE_PEPPER: ${ACTIVATION_CODE_PEPPER}
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: 3000
       RUST_LOG: ${RUST_LOG:-info}

--- a/iviss-backend/Cargo.lock
+++ b/iviss-backend/Cargo.lock
@@ -473,9 +473,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -713,6 +713,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +893,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1041,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1777,11 +1834,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "config",
  "deadpool-redis",
  "dotenvy",
+ "ed25519-dalek",
  "hmac",
  "image",
+ "jsonwebtoken",
  "leptess",
  "once_cell",
  "rand 0.8.5",
@@ -1835,6 +1895,21 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1958,9 +2033,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2419,6 +2494,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -3112,6 +3197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,14 +3220,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3475,6 +3569,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -3846,14 +3952,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -5173,7 +5279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/iviss-backend/Cargo.toml
+++ b/iviss-backend/Cargo.toml
@@ -36,6 +36,9 @@ reqwest = { version = "0.12", features = ["json"] }
 sha2 = "0.10"
 hmac = "0.12"
 rand = "0.8"
+base64 = "0.22"
+jsonwebtoken = "9.3"
+ed25519-dalek = "2.1"
 
 [dev-dependencies]
 testcontainers = "0.23"

--- a/iviss-backend/src/api_doc.rs
+++ b/iviss-backend/src/api_doc.rs
@@ -4,6 +4,9 @@ use utoipa::{
 };
 
 use crate::dto::{
+    auth::{
+        RefreshNonceRequest, RefreshNonceResponse, RefreshVerifyRequest, RefreshVerifyResponse,
+    },
     common::*,
     create_control::*,
     list_control::*,
@@ -65,6 +68,8 @@ impl Modify for SecurityAddon {
         crate::handlers::auth::login,
         crate::handlers::auth::register,
         crate::handlers::auth::logout,
+        crate::handlers::auth::create_refresh_nonce,
+        crate::handlers::auth::verify_refresh_signature,
         crate::handlers::auth::send_activation,
         crate::handlers::user_management::provision_user,
         crate::handlers::user_management::list_users,
@@ -120,6 +125,10 @@ impl Modify for SecurityAddon {
             crate::handlers::auth::RegisterRequest,
             crate::handlers::auth::SendActivationRequest,
             crate::handlers::auth::SendActivationResponse,
+            RefreshNonceRequest,
+            RefreshNonceResponse,
+            RefreshVerifyRequest,
+            RefreshVerifyResponse,
             ProvisionUserRequest,
             UpdateUserRequest,
             UserStatus,

--- a/iviss-backend/src/app_state.rs
+++ b/iviss-backend/src/app_state.rs
@@ -10,6 +10,7 @@ pub struct AppState {
     pub redis: RedisPool,
     pub sms_pvd: Arc<dyn SmsProvider>,
     pub pepper: String,
+    pub jwt_secret: String,
 }
 
 impl AppState {
@@ -18,12 +19,14 @@ impl AppState {
         redis_pool: RedisPool,
         sms_pvd: Arc<dyn SmsProvider>,
         pepper: String,
+        jwt_secret: String,
     ) -> Self {
         Self {
             db: db_pool,
             redis: redis_pool,
             sms_pvd,
             pepper,
+            jwt_secret,
         }
     }
 }

--- a/iviss-backend/src/dto/auth.rs
+++ b/iviss-backend/src/dto/auth.rs
@@ -1,1 +1,44 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
 
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshNonceRequest {
+    pub refresh_token: String,
+    pub device_id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshNonceResponse {
+    pub challenge_id: Uuid,
+    pub nonce: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshVerifyRequest {
+    pub refresh_token: String,
+    pub device_id: Uuid,
+    pub challenge_id: Uuid,
+    pub signature: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshVerifyResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccessTokenClaims {
+    pub sub: String,
+    pub device_id: Uuid,
+    pub jti: Uuid,
+    pub exp: i64,
+    pub iat: i64,
+}

--- a/iviss-backend/src/handlers/auth.rs
+++ b/iviss-backend/src/handlers/auth.rs
@@ -42,6 +42,14 @@ pub struct SendActivationResponse {
     pub message: String,
 }
 
+#[derive(Debug, sqlx::FromRow)]
+struct ActivationUserRow {
+    id: uuid::Uuid,
+    phone_number: String,
+    role: String,
+    status: String,
+}
+
 /// Login with email and password
 #[utoipa::path(
     post,
@@ -229,7 +237,7 @@ pub async fn send_activation(
     Json(payload): Json<SendActivationRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     // Fetch agent from DB
-    let user = sqlx::query!(
+    let user = sqlx::query_as::<_, ActivationUserRow>(
         r#"
         SELECT id, phone_number,
                role AS "role: String",
@@ -238,8 +246,8 @@ pub async fn send_activation(
         WHERE id = $1
         AND deleted_at IS NULL
         "#,
-        payload.user_id
     )
+    .bind(payload.user_id)
     .fetch_optional(&state.db)
     .await
     .map_err(AppError::Database)?

--- a/iviss-backend/src/handlers/auth.rs
+++ b/iviss-backend/src/handlers/auth.rs
@@ -1,7 +1,11 @@
 use crate::app_state::AppState;
+use crate::dto::auth::{
+    RefreshNonceRequest, RefreshNonceResponse, RefreshVerifyRequest, RefreshVerifyResponse,
+};
 use crate::dto::users::{UserProfile, UserRole};
 use crate::errors::AppError;
 use crate::services::activation_service::ActivationService;
+use crate::services::refresh_service::RefreshService;
 use axum::extract::State;
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
@@ -128,6 +132,83 @@ pub async fn register(Json(payload): Json<RegisterRequest>) -> Result<impl IntoR
 )]
 pub async fn logout() -> Result<impl IntoResponse, AppError> {
     Ok((StatusCode::OK, Json("Logout successful".to_string())))
+}
+
+/// Create nonce challenge for refresh-token proof-of-possession
+#[utoipa::path(
+    post,
+    path = "/auth/refresh/nonce",
+    request_body = RefreshNonceRequest,
+    responses(
+        (status = 200, description = "Nonce challenge generated", body = RefreshNonceResponse),
+        (status = 401, description = "Invalid refresh token or device binding", body = AppErrorResponse)
+    ),
+    tag = "auth",
+    operation_id = "createRefreshNonce"
+)]
+pub async fn create_refresh_nonce(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<RefreshNonceRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let refresh_service = RefreshService::new(
+        state.db.clone(),
+        state.redis.clone(),
+        state.jwt_secret.clone(),
+    );
+
+    let challenge = refresh_service
+        .create_nonce_challenge(&payload.refresh_token, payload.device_id)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(RefreshNonceResponse {
+            challenge_id: challenge.challenge_id,
+            nonce: challenge.nonce,
+            expires_in_seconds: challenge.expires_in_seconds,
+        }),
+    ))
+}
+
+/// Verify signed nonce for a refresh-token proof-of-possession and issue a new access token
+#[utoipa::path(
+    post,
+    path = "/auth/refresh/verify",
+    request_body = RefreshVerifyRequest,
+    responses(
+        (status = 200, description = "Signature verified and access token issued", body = RefreshVerifyResponse),
+        (status = 401, description = "Invalid signature, nonce, refresh token, or device binding", body = AppErrorResponse)
+    ),
+    tag = "auth",
+    operation_id = "verifyRefreshSignature"
+)]
+pub async fn verify_refresh_signature(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<RefreshVerifyRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let refresh_service = RefreshService::new(
+        state.db.clone(),
+        state.redis.clone(),
+        state.jwt_secret.clone(),
+    );
+
+    let access_token = refresh_service
+        .verify_and_issue_access_token(
+            &payload.refresh_token,
+            payload.device_id,
+            payload.challenge_id,
+            &payload.signature,
+        )
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(RefreshVerifyResponse {
+            access_token,
+            token_type: "Bearer".to_string(),
+            expires_in_seconds: crate::services::refresh_service::ACCESS_TOKEN_TTL_SECS,
+        }),
+    ))
 }
 
 /// Send activation code via SMS to a pending agent

--- a/iviss-backend/src/main.rs
+++ b/iviss-backend/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> anyhow::Result<()> {
         redis_pool,
         sms_provider,
         config.activation_code_pepper,
+        config.jwt_secret,
     );
     let app = routes::assembly(state)
         .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", ApiDoc::openapi()));

--- a/iviss-backend/src/routes.rs
+++ b/iviss-backend/src/routes.rs
@@ -51,6 +51,14 @@ pub fn assembly(state: AppState) -> Router {
         .route("/auth/register", post(crate::handlers::auth::register))
         .route("/auth/logout", post(crate::handlers::auth::logout))
         .route(
+            "/auth/refresh/nonce",
+            post(crate::handlers::auth::create_refresh_nonce),
+        )
+        .route(
+            "/auth/refresh/verify",
+            post(crate::handlers::auth::verify_refresh_signature),
+        )
+        .route(
             "/auth/send-activation",
             post(crate::handlers::auth::send_activation),
         )

--- a/iviss-backend/src/services/mod.rs
+++ b/iviss-backend/src/services/mod.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::all, dead_code, unused_variables)]
 
 pub mod activation_service;
-pub mod sms_provider;
 pub mod ocr_service;
 pub mod photo_ocr_service;
+pub mod refresh_service;
+pub mod sms_provider;
 pub mod vehicle_service;

--- a/iviss-backend/src/services/refresh_service.rs
+++ b/iviss-backend/src/services/refresh_service.rs
@@ -1,0 +1,322 @@
+use crate::db::{DbPool, RedisPool};
+use crate::dto::auth::AccessTokenClaims;
+use crate::errors::AppError;
+use anyhow::Context;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::Engine;
+use deadpool_redis::redis::AsyncCommands;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use rand::rngs::OsRng;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+pub const NONCE_TTL_SECS: u64 = 90;
+pub const ACCESS_TOKEN_TTL_SECS: u64 = 15 * 60;
+const NONCE_KEY_PREFIX: &str = "refresh_nonce";
+
+#[derive(Debug, Clone)]
+pub struct NonceChallenge {
+    pub challenge_id: Uuid,
+    pub nonce: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RefreshNonceEntry {
+    token_hash: String,
+    user_id: Uuid,
+    device_id: Uuid,
+    nonce: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct RefreshBindingRow {
+    user_id: Uuid,
+    device_id: Uuid,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct RefreshBindingWithKeyRow {
+    user_id: Uuid,
+    device_id: Uuid,
+    public_key: String,
+}
+
+pub struct RefreshService {
+    db: DbPool,
+    redis: RedisPool,
+    jwt_secret: String,
+}
+
+impl RefreshService {
+    pub fn new(db: DbPool, redis: RedisPool, jwt_secret: String) -> Self {
+        Self {
+            db,
+            redis,
+            jwt_secret,
+        }
+    }
+
+    pub fn hash_refresh_token(refresh_token: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(refresh_token.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    pub async fn create_nonce_challenge(
+        &self,
+        refresh_token: &str,
+        device_id: Uuid,
+    ) -> Result<NonceChallenge, AppError> {
+        let token_hash = Self::hash_refresh_token(refresh_token);
+        let binding = self
+            .fetch_active_refresh_binding(&token_hash, device_id)
+            .await?;
+
+        let challenge_id = Uuid::new_v4();
+        let nonce = Self::generate_nonce();
+        let key = Self::redis_key(challenge_id);
+
+        let entry = RefreshNonceEntry {
+            token_hash,
+            user_id: binding.user_id,
+            device_id: binding.device_id,
+            nonce: nonce.clone(),
+        };
+
+        let payload =
+            serde_json::to_string(&entry).context("Failed to serialize refresh nonce entry")?;
+
+        let mut conn = self
+            .redis
+            .get()
+            .await
+            .context("Failed to get Redis connection for refresh nonce")?;
+
+        conn.set_ex::<_, _, ()>(&key, payload, NONCE_TTL_SECS)
+            .await
+            .context("Failed to store refresh nonce challenge in Redis")?;
+
+        Ok(NonceChallenge {
+            challenge_id,
+            nonce,
+            expires_in_seconds: NONCE_TTL_SECS,
+        })
+    }
+
+    pub async fn verify_and_issue_access_token(
+        &self,
+        refresh_token: &str,
+        device_id: Uuid,
+        challenge_id: Uuid,
+        signature: &str,
+    ) -> Result<String, AppError> {
+        let token_hash = Self::hash_refresh_token(refresh_token);
+        let nonce_entry = self.consume_nonce_challenge(challenge_id).await?;
+
+        if nonce_entry.token_hash != token_hash || nonce_entry.device_id != device_id {
+            self.revoke_refresh_token(&nonce_entry.token_hash).await?;
+            return Err(AppError::unauthorized(
+                "Refresh challenge does not match token or device",
+            ));
+        }
+
+        let binding = self
+            .fetch_active_refresh_binding_with_key(&token_hash, device_id)
+            .await?;
+        if self
+            .verify_device_signature(&binding.public_key, &nonce_entry.nonce, signature)
+            .is_err()
+        {
+            self.revoke_refresh_token(&token_hash).await?;
+            return Err(AppError::unauthorized("Invalid device signature"));
+        }
+
+        self.issue_access_token(binding.user_id, binding.device_id)
+    }
+
+    async fn fetch_active_refresh_binding(
+        &self,
+        token_hash: &str,
+        device_id: Uuid,
+    ) -> Result<RefreshBindingRow, AppError> {
+        sqlx::query_as::<_, RefreshBindingRow>(
+            r#"
+            SELECT rt.user_id, rt.device_id
+            FROM refresh_tokens rt
+            INNER JOIN users u ON u.id = rt.user_id
+            INNER JOIN devices d ON d.id = rt.device_id
+            WHERE rt.token_hash = $1
+              AND rt.device_id = $2
+              AND rt.revoked = FALSE
+              AND rt.expires_at > NOW()
+              AND u.deleted_at IS NULL
+              AND u.status::TEXT = 'ACTIVE'
+              AND d.user_id = u.id
+              AND d.status::TEXT = 'ACTIVE'
+            "#,
+        )
+        .bind(token_hash)
+        .bind(device_id)
+        .fetch_optional(&self.db)
+        .await
+        .map_err(AppError::database)?
+        .ok_or_else(|| AppError::unauthorized("Invalid refresh token or device binding"))
+    }
+
+    async fn fetch_active_refresh_binding_with_key(
+        &self,
+        token_hash: &str,
+        device_id: Uuid,
+    ) -> Result<RefreshBindingWithKeyRow, AppError> {
+        sqlx::query_as::<_, RefreshBindingWithKeyRow>(
+            r#"
+            SELECT rt.user_id, rt.device_id, d.public_key
+            FROM refresh_tokens rt
+            INNER JOIN users u ON u.id = rt.user_id
+            INNER JOIN devices d ON d.id = rt.device_id
+            WHERE rt.token_hash = $1
+              AND rt.device_id = $2
+              AND rt.revoked = FALSE
+              AND rt.expires_at > NOW()
+              AND u.deleted_at IS NULL
+              AND u.status::TEXT = 'ACTIVE'
+              AND d.user_id = u.id
+              AND d.status::TEXT = 'ACTIVE'
+            "#,
+        )
+        .bind(token_hash)
+        .bind(device_id)
+        .fetch_optional(&self.db)
+        .await
+        .map_err(AppError::database)?
+        .ok_or_else(|| AppError::unauthorized("Invalid refresh token or device binding"))
+    }
+
+    async fn consume_nonce_challenge(
+        &self,
+        challenge_id: Uuid,
+    ) -> Result<RefreshNonceEntry, AppError> {
+        let key = Self::redis_key(challenge_id);
+        let mut conn = self
+            .redis
+            .get()
+            .await
+            .context("Failed to get Redis connection for refresh challenge verification")?;
+
+        let raw: Option<String> = redis::cmd("GETDEL")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await
+            .context("Failed to consume refresh nonce challenge from Redis")?;
+
+        let raw = raw.ok_or_else(|| {
+            AppError::unauthorized("Nonce challenge expired or already used (replay rejected)")
+        })?;
+
+        serde_json::from_str(&raw)
+            .context("Failed to deserialize refresh nonce challenge")
+            .map_err(AppError::from)
+    }
+
+    fn verify_device_signature(
+        &self,
+        public_key: &str,
+        nonce: &str,
+        signature: &str,
+    ) -> Result<(), AppError> {
+        let public_key_bytes = Self::decode_input_bytes(public_key)
+            .ok_or_else(|| AppError::unauthorized("Invalid stored device public key encoding"))?;
+        let public_key_bytes: [u8; 32] = public_key_bytes
+            .try_into()
+            .map_err(|_| AppError::unauthorized("Invalid stored device public key length"))?;
+
+        let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+            .map_err(|_| AppError::unauthorized("Invalid stored device public key"))?;
+
+        let signature_bytes = Self::decode_input_bytes(signature)
+            .ok_or_else(|| AppError::unauthorized("Invalid signature encoding"))?;
+        let signature_bytes: [u8; 64] = signature_bytes
+            .try_into()
+            .map_err(|_| AppError::unauthorized("Invalid signature length"))?;
+
+        let signature = Signature::from_bytes(&signature_bytes);
+        verifying_key
+            .verify(nonce.as_bytes(), &signature)
+            .map_err(|_| AppError::unauthorized("Invalid device signature"))
+    }
+
+    fn issue_access_token(&self, user_id: Uuid, device_id: Uuid) -> Result<String, AppError> {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let exp = now + ACCESS_TOKEN_TTL_SECS as i64;
+        let claims = AccessTokenClaims {
+            sub: user_id.to_string(),
+            device_id,
+            jti: Uuid::new_v4(),
+            exp,
+            iat: now,
+        };
+
+        jsonwebtoken::encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(self.jwt_secret.as_bytes()),
+        )
+        .map_err(|e| AppError::internal_error(format!("Failed to issue access token: {e}")))
+    }
+
+    pub async fn revoke_refresh_token(&self, token_hash: &str) -> Result<(), AppError> {
+        sqlx::query(
+            r#"
+            UPDATE refresh_tokens
+            SET revoked = TRUE, revoked_at = NOW()
+            WHERE token_hash = $1 AND revoked = FALSE
+            "#,
+        )
+        .bind(token_hash)
+        .execute(&self.db)
+        .await
+        .map_err(AppError::database)?;
+
+        Ok(())
+    }
+
+    fn redis_key(challenge_id: Uuid) -> String {
+        format!("{NONCE_KEY_PREFIX}:{challenge_id}")
+    }
+
+    fn generate_nonce() -> String {
+        let mut nonce_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        URL_SAFE_NO_PAD.encode(nonce_bytes)
+    }
+
+    fn decode_input_bytes(input: &str) -> Option<Vec<u8>> {
+        if let Ok(decoded) = STANDARD.decode(input) {
+            return Some(decoded);
+        }
+
+        if let Ok(decoded) = URL_SAFE_NO_PAD.decode(input) {
+            return Some(decoded);
+        }
+
+        Self::decode_hex(input).ok()
+    }
+
+    fn decode_hex(hex_input: &str) -> Result<Vec<u8>, ()> {
+        if hex_input.len() % 2 != 0 {
+            return Err(());
+        }
+
+        let mut out = Vec::with_capacity(hex_input.len() / 2);
+        for idx in (0..hex_input.len()).step_by(2) {
+            let byte = u8::from_str_radix(&hex_input[idx..idx + 2], 16).map_err(|_| ())?;
+            out.push(byte);
+        }
+        Ok(out)
+    }
+}

--- a/iviss-backend/src/services/refresh_service.rs
+++ b/iviss-backend/src/services/refresh_service.rs
@@ -208,9 +208,19 @@ impl RefreshService {
             .await
             .context("Failed to get Redis connection for refresh challenge verification")?;
 
-        let raw: Option<String> = redis::cmd("GETDEL")
-            .arg(&key)
-            .query_async(&mut conn)
+        let script = redis::Script::new(
+            r#"
+            local value = redis.call("GET", KEYS[1])
+            if value then
+                redis.call("DEL", KEYS[1])
+            end
+            return value
+            "#,
+        );
+
+        let raw: Option<String> = script
+            .key(&key)
+            .invoke_async(&mut conn)
             .await
             .context("Failed to consume refresh nonce challenge from Redis")?;
 

--- a/iviss-backend/src/tests/mod.rs
+++ b/iviss-backend/src/tests/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
 pub mod activation_service_tests;
+#[cfg(test)]
+pub mod refresh_service_tests;

--- a/iviss-backend/src/tests/refresh_service_tests.rs
+++ b/iviss-backend/src/tests/refresh_service_tests.rs
@@ -8,17 +8,20 @@ use deadpool_redis::{Config as RedisConfig, Runtime};
 use ed25519_dalek::{Signer, SigningKey};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use sqlx::PgPool;
-use testcontainers::core::{IntoContainerPort, WaitFor};
+use testcontainers::core::IntoContainerPort;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{ContainerAsync, GenericImage};
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
 use testcontainers_modules::redis::Redis;
+use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
 const TEST_JWT_SECRET: &str = "be06-refresh-jwt-secret-must-be-at-least-32-chars";
+const DEFAULT_TEST_DATABASE_URL: &str = "postgres://iviss_user:iviss_password@127.0.0.1:5435/iviss_db";
+const DEFAULT_TEST_REDIS_URL: &str = "redis://127.0.0.1:6380";
 
 struct TestContext {
-    _pg_container: ContainerAsync<GenericImage>,
-    _redis_container: ContainerAsync<Redis>,
+    _pg_container: Option<ContainerAsync<GenericImage>>,
+    _redis_container: Option<ContainerAsync<Redis>>,
     db_pool: PgPool,
     redis_pool: RedisPool,
 }
@@ -31,19 +34,29 @@ struct SeedData {
 }
 
 async fn setup_context() -> TestContext {
+    let database_url =
+        std::env::var("BE06_TEST_DATABASE_URL").unwrap_or_else(|_| DEFAULT_TEST_DATABASE_URL.to_string());
+    let redis_url =
+        std::env::var("BE06_TEST_REDIS_URL").unwrap_or_else(|_| DEFAULT_TEST_REDIS_URL.to_string());
+
+    // Prefer already-running local services; this avoids requiring Docker socket
+    // access for every local test run.
+    if let Ok(context) = try_setup_external_context(&database_url, &redis_url).await {
+        return context;
+    }
+
     let pg_image = GenericImage::new("postgres", "15-alpine")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
         .with_env_var("POSTGRES_DB", "iviss")
-        .with_exposed_port(5432.tcp())
-        .with_wait_for(WaitFor::message_on_stderr(
-            "database system is ready to accept connections",
-        ));
+        .with_mapped_port(0, 5432.tcp());
     let pg_container = pg_image.start().await.unwrap();
     let pg_port = pg_container.get_host_port_ipv4(5432).await.unwrap();
 
     let database_url = format!("postgres://postgres:postgres@127.0.0.1:{pg_port}/iviss");
-    let db_pool = PgPool::connect(&database_url).await.unwrap();
+    let db_pool = connect_with_retry(&database_url)
+        .await
+        .unwrap_or_else(|err| panic!("Failed to connect to container postgres after retries: {err}"));
     sqlx::migrate!("./migrations").run(&db_pool).await.unwrap();
 
     let redis_container = Redis::default().start().await.unwrap();
@@ -54,11 +67,57 @@ async fn setup_context() -> TestContext {
         .unwrap();
 
     TestContext {
-        _pg_container: pg_container,
-        _redis_container: redis_container,
+        _pg_container: Some(pg_container),
+        _redis_container: Some(redis_container),
         db_pool,
         redis_pool,
     }
+}
+
+async fn try_setup_external_context(database_url: &str, redis_url: &str) -> Result<TestContext, String> {
+    let db_pool = connect_with_retry(database_url)
+        .await
+        .map_err(|err| format!("database connect failed: {err}"))?;
+
+    sqlx::migrate!("./migrations")
+        .run(&db_pool)
+        .await
+        .map_err(|err| format!("migration failed: {err}"))?;
+
+    let redis_pool = RedisConfig::from_url(redis_url)
+        .create_pool(Some(Runtime::Tokio1))
+        .map_err(|err| format!("redis pool creation failed: {err}"))?;
+
+    let mut redis_conn = redis_pool
+        .get()
+        .await
+        .map_err(|err| format!("redis connection failed: {err}"))?;
+    let _: String = redis::cmd("PING")
+        .query_async(&mut redis_conn)
+        .await
+        .map_err(|err| format!("redis ping failed: {err}"))?;
+
+    Ok(TestContext {
+        _pg_container: None,
+        _redis_container: None,
+        db_pool,
+        redis_pool,
+    })
+}
+
+async fn connect_with_retry(database_url: &str) -> Result<PgPool, sqlx::Error> {
+    for attempt in 1..=10 {
+        match PgPool::connect(database_url).await {
+            Ok(pool) => return Ok(pool),
+            Err(err) => {
+                if attempt == 10 {
+                    return Err(err);
+                }
+                sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    unreachable!("retry loop should always return");
 }
 
 async fn seed_active_refresh_token(pool: &PgPool) -> SeedData {
@@ -67,6 +126,10 @@ async fn seed_active_refresh_token(pool: &PgPool) -> SeedData {
     let device_id = Uuid::new_v4();
     let refresh_token = format!("refresh-{}", Uuid::new_v4());
     let refresh_token_hash = RefreshService::hash_refresh_token(&refresh_token);
+    let username = format!("be06-agent-{}", &user_id.simple().to_string()[..8]);
+    let badge_id = format!("AG-{}", &user_id.simple().to_string()[..6].to_uppercase());
+    let phone_suffix: u32 = rand::random::<u32>() % 10_000_000;
+    let phone_number = format!("+2376{phone_suffix:07}");
 
     let secret_key: [u8; 32] = rand::random();
     let signing_key = SigningKey::from_bytes(&secret_key);
@@ -89,12 +152,15 @@ async fn seed_active_refresh_token(pool: &PgPool) -> SeedData {
             id, organization_id, username, email, password_hash, role, badge_id, full_name, phone_number, status, deleted_at
         )
         VALUES (
-            $1, $2, 'be06-agent', NULL, NULL, 'agent'::user_role, 'AG-BE06', 'BE06 Agent', '+237600123456', 'ACTIVE'::user_status, NULL
+            $1, $2, $3, NULL, NULL, 'agent'::user_role, $4, 'BE06 Agent', $5, 'ACTIVE'::user_status, NULL
         )
         "#,
     )
     .bind(user_id)
     .bind(organization_id)
+    .bind(username)
+    .bind(badge_id)
+    .bind(phone_number)
     .execute(pool)
     .await
     .unwrap();

--- a/iviss-backend/src/tests/refresh_service_tests.rs
+++ b/iviss-backend/src/tests/refresh_service_tests.rs
@@ -16,7 +16,8 @@ use tokio::time::{sleep, Duration};
 use uuid::Uuid;
 
 const TEST_JWT_SECRET: &str = "be06-refresh-jwt-secret-must-be-at-least-32-chars";
-const DEFAULT_TEST_DATABASE_URL: &str = "postgres://iviss_user:iviss_password@127.0.0.1:5435/iviss_db";
+const DEFAULT_TEST_DATABASE_URL: &str =
+    "postgres://iviss_user:iviss_password@127.0.0.1:5435/iviss_db";
 const DEFAULT_TEST_REDIS_URL: &str = "redis://127.0.0.1:6380";
 
 struct TestContext {
@@ -34,8 +35,8 @@ struct SeedData {
 }
 
 async fn setup_context() -> TestContext {
-    let database_url =
-        std::env::var("BE06_TEST_DATABASE_URL").unwrap_or_else(|_| DEFAULT_TEST_DATABASE_URL.to_string());
+    let database_url = std::env::var("BE06_TEST_DATABASE_URL")
+        .unwrap_or_else(|_| DEFAULT_TEST_DATABASE_URL.to_string());
     let redis_url =
         std::env::var("BE06_TEST_REDIS_URL").unwrap_or_else(|_| DEFAULT_TEST_REDIS_URL.to_string());
 
@@ -56,7 +57,9 @@ async fn setup_context() -> TestContext {
     let database_url = format!("postgres://postgres:postgres@127.0.0.1:{pg_port}/iviss");
     let db_pool = connect_with_retry(&database_url)
         .await
-        .unwrap_or_else(|err| panic!("Failed to connect to container postgres after retries: {err}"));
+        .unwrap_or_else(|err| {
+            panic!("Failed to connect to container postgres after retries: {err}")
+        });
     sqlx::migrate!("./migrations").run(&db_pool).await.unwrap();
 
     let redis_container = Redis::default().start().await.unwrap();
@@ -74,7 +77,10 @@ async fn setup_context() -> TestContext {
     }
 }
 
-async fn try_setup_external_context(database_url: &str, redis_url: &str) -> Result<TestContext, String> {
+async fn try_setup_external_context(
+    database_url: &str,
+    redis_url: &str,
+) -> Result<TestContext, String> {
     let db_pool = connect_with_retry(database_url)
         .await
         .map_err(|err| format!("database connect failed: {err}"))?;

--- a/iviss-backend/src/tests/refresh_service_tests.rs
+++ b/iviss-backend/src/tests/refresh_service_tests.rs
@@ -1,0 +1,265 @@
+use crate::db::RedisPool;
+use crate::dto::auth::AccessTokenClaims;
+use crate::errors::AppError;
+use crate::services::refresh_service::{RefreshService, ACCESS_TOKEN_TTL_SECS};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use deadpool_redis::{Config as RedisConfig, Runtime};
+use ed25519_dalek::{Signer, SigningKey};
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use sqlx::PgPool;
+use testcontainers::core::{IntoContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage};
+use testcontainers_modules::redis::Redis;
+use uuid::Uuid;
+
+const TEST_JWT_SECRET: &str = "be06-refresh-jwt-secret-must-be-at-least-32-chars";
+
+struct TestContext {
+    _pg_container: ContainerAsync<GenericImage>,
+    _redis_container: ContainerAsync<Redis>,
+    db_pool: PgPool,
+    redis_pool: RedisPool,
+}
+
+struct SeedData {
+    user_id: Uuid,
+    device_id: Uuid,
+    refresh_token: String,
+    signing_key: SigningKey,
+}
+
+async fn setup_context() -> TestContext {
+    let pg_image = GenericImage::new("postgres", "15-alpine")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_DB", "iviss")
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ));
+    let pg_container = pg_image.start().await.unwrap();
+    let pg_port = pg_container.get_host_port_ipv4(5432).await.unwrap();
+
+    let database_url = format!("postgres://postgres:postgres@127.0.0.1:{pg_port}/iviss");
+    let db_pool = PgPool::connect(&database_url).await.unwrap();
+    sqlx::migrate!("./migrations").run(&db_pool).await.unwrap();
+
+    let redis_container = Redis::default().start().await.unwrap();
+    let redis_port = redis_container.get_host_port_ipv4(6379).await.unwrap();
+    let redis_url = format!("redis://127.0.0.1:{redis_port}");
+    let redis_pool = RedisConfig::from_url(redis_url)
+        .create_pool(Some(Runtime::Tokio1))
+        .unwrap();
+
+    TestContext {
+        _pg_container: pg_container,
+        _redis_container: redis_container,
+        db_pool,
+        redis_pool,
+    }
+}
+
+async fn seed_active_refresh_token(pool: &PgPool) -> SeedData {
+    let organization_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let device_id = Uuid::new_v4();
+    let refresh_token = format!("refresh-{}", Uuid::new_v4());
+    let refresh_token_hash = RefreshService::hash_refresh_token(&refresh_token);
+
+    let secret_key: [u8; 32] = rand::random();
+    let signing_key = SigningKey::from_bytes(&secret_key);
+    let public_key = STANDARD.encode(signing_key.verifying_key().as_bytes());
+
+    sqlx::query(
+        r#"
+        INSERT INTO organizations (id, name, type, region, deleted_at)
+        VALUES ($1, 'BE06 Test Org', 'police', 'Centre', NULL)
+        "#,
+    )
+    .bind(organization_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        INSERT INTO users (
+            id, organization_id, username, email, password_hash, role, badge_id, full_name, phone_number, status, deleted_at
+        )
+        VALUES (
+            $1, $2, 'be06-agent', NULL, NULL, 'agent'::user_role, 'AG-BE06', 'BE06 Agent', '+237600123456', 'ACTIVE'::user_status, NULL
+        )
+        "#,
+    )
+    .bind(user_id)
+    .bind(organization_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        INSERT INTO devices (id, user_id, public_key, metadata, status)
+        VALUES ($1, $2, $3, '{}'::jsonb, 'ACTIVE'::device_status)
+        "#,
+    )
+    .bind(device_id)
+    .bind(user_id)
+    .bind(public_key)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        INSERT INTO refresh_tokens (token_hash, user_id, device_id, expires_at, revoked)
+        VALUES ($1, $2, $3, NOW() + INTERVAL '30 days', FALSE)
+        "#,
+    )
+    .bind(refresh_token_hash)
+    .bind(user_id)
+    .bind(device_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    SeedData {
+        user_id,
+        device_id,
+        refresh_token,
+        signing_key,
+    }
+}
+
+#[tokio::test]
+async fn refresh_flow_issues_access_token_after_valid_signature() {
+    let ctx = setup_context().await;
+    let seed = seed_active_refresh_token(&ctx.db_pool).await;
+    let refresh_service = RefreshService::new(
+        ctx.db_pool.clone(),
+        ctx.redis_pool.clone(),
+        TEST_JWT_SECRET.to_string(),
+    );
+
+    let challenge = refresh_service
+        .create_nonce_challenge(&seed.refresh_token, seed.device_id)
+        .await
+        .unwrap();
+    let signature = seed.signing_key.sign(challenge.nonce.as_bytes());
+    let signature_b64 = STANDARD.encode(signature.to_bytes());
+
+    let access_token = refresh_service
+        .verify_and_issue_access_token(
+            &seed.refresh_token,
+            seed.device_id,
+            challenge.challenge_id,
+            &signature_b64,
+        )
+        .await
+        .unwrap();
+
+    let decoded = decode::<AccessTokenClaims>(
+        &access_token,
+        &DecodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+        &Validation::new(Algorithm::HS256),
+    )
+    .unwrap();
+
+    assert_eq!(decoded.claims.sub, seed.user_id.to_string());
+    assert_eq!(decoded.claims.device_id, seed.device_id);
+    assert_eq!(access_token.split('.').count(), 3);
+    assert!(
+        decoded.claims.exp - decoded.claims.iat <= ACCESS_TOKEN_TTL_SECS as i64,
+        "access token lifetime should stay within configured TTL"
+    );
+}
+
+#[tokio::test]
+async fn refresh_flow_rejects_nonce_replay() {
+    let ctx = setup_context().await;
+    let seed = seed_active_refresh_token(&ctx.db_pool).await;
+    let refresh_service = RefreshService::new(
+        ctx.db_pool.clone(),
+        ctx.redis_pool.clone(),
+        TEST_JWT_SECRET.to_string(),
+    );
+
+    let challenge = refresh_service
+        .create_nonce_challenge(&seed.refresh_token, seed.device_id)
+        .await
+        .unwrap();
+    let signature = seed.signing_key.sign(challenge.nonce.as_bytes());
+    let signature_b64 = STANDARD.encode(signature.to_bytes());
+
+    refresh_service
+        .verify_and_issue_access_token(
+            &seed.refresh_token,
+            seed.device_id,
+            challenge.challenge_id,
+            &signature_b64,
+        )
+        .await
+        .unwrap();
+
+    let replay_attempt = refresh_service
+        .verify_and_issue_access_token(
+            &seed.refresh_token,
+            seed.device_id,
+            challenge.challenge_id,
+            &signature_b64,
+        )
+        .await;
+
+    assert!(matches!(
+        replay_attempt,
+        Err(AppError::Unauthorized(message))
+            if message.contains("already used") || message.contains("replay")
+    ));
+}
+
+#[tokio::test]
+async fn refresh_flow_revokes_token_when_signature_is_invalid() {
+    let ctx = setup_context().await;
+    let seed = seed_active_refresh_token(&ctx.db_pool).await;
+    let refresh_service = RefreshService::new(
+        ctx.db_pool.clone(),
+        ctx.redis_pool.clone(),
+        TEST_JWT_SECRET.to_string(),
+    );
+
+    let challenge = refresh_service
+        .create_nonce_challenge(&seed.refresh_token, seed.device_id)
+        .await
+        .unwrap();
+
+    let wrong_secret_key: [u8; 32] = rand::random();
+    let wrong_signing_key = SigningKey::from_bytes(&wrong_secret_key);
+    let wrong_signature = wrong_signing_key.sign(challenge.nonce.as_bytes());
+    let wrong_signature_b64 = STANDARD.encode(wrong_signature.to_bytes());
+
+    let verify_result = refresh_service
+        .verify_and_issue_access_token(
+            &seed.refresh_token,
+            seed.device_id,
+            challenge.challenge_id,
+            &wrong_signature_b64,
+        )
+        .await;
+    assert!(matches!(verify_result, Err(AppError::Unauthorized(_))));
+
+    let token_hash = RefreshService::hash_refresh_token(&seed.refresh_token);
+    let revoked: bool = sqlx::query_scalar(
+        r#"
+        SELECT revoked
+        FROM refresh_tokens
+        WHERE token_hash = $1
+        "#,
+    )
+    .bind(token_hash)
+    .fetch_one(&ctx.db_pool)
+    .await
+    .unwrap();
+    assert!(revoked, "invalid signature should revoke suspicious token");
+}


### PR DESCRIPTION
- Added refresh nonce challenge flow backed by Redis with one-time consumption.
- Verified Ed25519 signatures against stored device public keys before issuing access tokens.
- Revoked refresh tokens when nonce/device/token mismatches or signature validation fails.
- Replaced Redis `GETDEL` usage with a Lua script to support older Redis versions.
- Added integration tests for nonce replay, valid signature, and invalid signature revocation.

**Acceptance Criteria**
- [x] Validates refresh token hash.
- [x] Validates token linked to `device_id`.
- [x] Generates nonce challenge.
- [x] Accepts signed nonce.
- [x] Verifies signature using stored `public_key`.
- [x] Rejects replayed nonce.
- [x] Issues new access token only after verification.

**API**
- `POST /auth/refresh/nonce`
- `POST /auth/refresh/verify`

**Notes**
- Nonce TTL is `90s` (within the 1-2 minute requirement).
- Access token TTL remains `15m`.

**Tests**
- `iviss-backend/src/tests/refresh_service_tests.rs`
- `cargo test refresh_service_tests -- --nocapture` (pass: 3/3)
- `cargo test --verbose` (pass: 29/29)
