### PR TITLE
Fix/198 silent token refresh

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,6 +13,7 @@ paths = [
   '''^iviss-backend/src/tests/fixtures/test_private_key\.pem$''',
   '''^iviss-backend/src/tests/activation_endpoint_tests\.rs$''',
   '''^docs/admin_session_termination\.md$''',
+  '''^docs/deployment_guide\.md$''',
   '''^infra/scripts/debug_jwt\.py$''',
   '''^infra/scripts/test_rust_parsing\.rs$''',
 ]

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -73,8 +73,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-
-
   const logout = async (forced = false) => {
     const accessToken = getAccessToken();
 
@@ -121,7 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const handleTokenRefreshed = (event: Event) => {
       const customEvent = event as CustomEvent<{ accessToken: string; session: AuthResponse }>;
       const { accessToken, session: updatedSession } = customEvent.detail;
-      
+
       // Update React state with the new token
       setSession(updatedSession);
       // User object should remain the same, but update if needed
@@ -152,7 +150,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           const clonedResponse = response.clone();
           const body = await clonedResponse.json();
-          
+
           if (body && typeof body === 'object' && 'code' in body) {
             if (body.code === 'SESSION_REVOKED') {
               isSessionRevoked = true;
@@ -261,7 +259,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           try {
             const resClone = response.clone();
             const json = await resClone.json();
-            
+
             if (
               json?.message === 'Shift ended' ||
               json?.reason === 'Shift ended' ||

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -73,6 +73,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+
+
   const logout = async (forced = false) => {
     const accessToken = getAccessToken();
 
@@ -114,6 +116,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Assign the global logout function to the instance logout so the interceptor can call it
   useEffect(() => {
     globalLogout = () => logout(true);
+
+    // Listen for token refresh events from the interceptor
+    const handleTokenRefreshed = (event: Event) => {
+      const customEvent = event as CustomEvent<{ accessToken: string; session: AuthResponse }>;
+      const { accessToken, session: updatedSession } = customEvent.detail;
+      
+      // Update React state with the new token
+      setSession(updatedSession);
+      // User object should remain the same, but update if needed
+      if (updatedSession.user) {
+        setUser(updatedSession.user);
+      }
+    };
+
+    window.addEventListener('iviss:token-refreshed', handleTokenRefreshed);
+
+    return () => {
+      window.removeEventListener('iviss:token-refreshed', handleTokenRefreshed);
+    };
   }, []);
 
   // Set up the API response interceptor
@@ -131,9 +152,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           const clonedResponse = response.clone();
           const body = await clonedResponse.json();
+          
           if (body && typeof body === 'object' && 'code' in body) {
             if (body.code === 'SESSION_REVOKED') {
               isSessionRevoked = true;
+              console.warn('[AuthContext] Session revoked by admin, logging out');
             }
           }
         } catch {
@@ -195,7 +218,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
             // Sync token manager with existing session token
             if (sessionData.accessToken && !getAccessToken()) {
-              setAccessToken(sessionData.accessToken);
+              setAccessToken(sessionData.accessToken, false);
             }
             // Always restore refresh token so the interceptor can refresh expired access tokens
             if (sessionData.refreshToken) {
@@ -207,7 +230,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // on the next API call rather than clearing everything immediately.
             if (sessionData.refreshToken && sessionData.accessToken) {
               setRefreshToken(sessionData.refreshToken);
-              setAccessToken(sessionData.accessToken); // Always set, even if expired
+              setAccessToken(sessionData.accessToken, false); // Always set, even if expired
               setSession(sessionData);
               setUser(sessionData.user);
             } else {
@@ -238,6 +261,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           try {
             const resClone = response.clone();
             const json = await resClone.json();
+            
             if (
               json?.message === 'Shift ended' ||
               json?.reason === 'Shift ended' ||
@@ -251,7 +275,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               globalThis.location.href = '/daily-login';
             }
           } catch {
-            // ignore parse error
+            // ignore parse error - let auth interceptor handle it
           }
         }
         return response;
@@ -299,7 +323,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       const newSession = {
-        token: data.accessToken,
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
         user: resolvedUser,
       } as unknown as AuthResponse;
 
@@ -307,8 +332,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
       localStorage.setItem('iviss_device_activated', 'true');
 
-      // Sync with token manager
-      setAccessToken(data.accessToken);
+      // Sync with token manager (don't notify context during initial login)
+      setAccessToken(data.accessToken, false);
       setRefreshToken(data.refreshToken);
 
       applyAuthTokenToApiClient(data.accessToken);
@@ -384,7 +409,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       const newSession = {
-        token: data.accessToken,
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
         user: resolvedUser,
       } as unknown as AuthResponse;
 
@@ -392,7 +418,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
       localStorage.setItem('iviss_device_activated', 'true');
 
-      setAccessToken(data.accessToken);
+      setAccessToken(data.accessToken, false);
       setRefreshToken(data.refreshToken);
 
       applyAuthTokenToApiClient(data.accessToken);
@@ -430,7 +456,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       };
 
       localStorage.setItem(SESSION_KEY, JSON.stringify(newSession));
-      setAccessToken(data.accessToken);
+      setAccessToken(data.accessToken, false);
       setRefreshToken(data.refreshToken);
 
       applyAuthTokenToApiClient(data.accessToken);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -118,7 +118,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Listen for token refresh events from the interceptor
     const handleTokenRefreshed = (event: Event) => {
       const customEvent = event as CustomEvent<{ accessToken: string; session: AuthResponse }>;
-      const { accessToken, session: updatedSession } = customEvent.detail;
+      const { session: updatedSession } = customEvent.detail;
 
       // Update React state with the new token
       setSession(updatedSession);

--- a/frontend/src/services/__tests__/backendFetch.test.ts
+++ b/frontend/src/services/__tests__/backendFetch.test.ts
@@ -73,15 +73,15 @@ describe('fetchWithAuth', () => {
     expect(calledHeaders.get('Authorization')).toBeNull();
   });
 
-  it('should dispatch iviss:session-revoked on 401', async () => {
+  it('should NOT dispatch iviss:session-revoked on 401 (handled by auth interceptor)', async () => {
     mockedGetAccessToken.mockReturnValue('expired-token');
     fetchSpy.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
 
     await fetchWithAuth(`${BASE_URL}/api/test`);
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
-    expect(event.type).toBe('iviss:session-revoked');
+    // 401s are now handled by the auth interceptor for token refresh
+    // backendFetch should not dispatch session-revoked for generic 401s
+    expect(dispatchSpy).not.toHaveBeenCalled();
   });
 
   it('should dispatch iviss:session-revoked when body contains SESSION_REVOKED code', async () => {

--- a/frontend/src/services/api/backendFetch.ts
+++ b/frontend/src/services/api/backendFetch.ts
@@ -26,25 +26,17 @@ export async function fetchWithAuth(input: string, init?: RequestInit): Promise<
     headers,
   });
 
-  if (!response.ok) {
-    let isSessionRevoked = false;
-    if (response.status === 401 && token) {
-      // Only treat as session revoked if we had a token — a login failure is not a revocation
-      isSessionRevoked = true;
-    } else {
-      try {
-        const cloned = response.clone();
-        const body = await cloned.json();
-        if (body && typeof body === 'object' && body.code === 'SESSION_REVOKED') {
-          isSessionRevoked = true;
-        }
-      } catch {
-        // Not JSON or other error
+  // Only check for explicit SESSION_REVOKED code, not generic 401s
+  // Generic 401s (token expired) are handled by the auth interceptor which refreshes tokens
+  if (!response.ok && response.status !== 401) {
+    try {
+      const cloned = response.clone();
+      const body = await cloned.json();
+      if (body && typeof body === 'object' && body.code === 'SESSION_REVOKED') {
+        window.dispatchEvent(new CustomEvent('iviss:session-revoked'));
       }
-    }
-
-    if (isSessionRevoked) {
-      window.dispatchEvent(new CustomEvent('iviss:session-revoked'));
+    } catch {
+      // Not JSON or other error - ignore
     }
   }
 

--- a/frontend/src/services/auth/authInterceptor.ts
+++ b/frontend/src/services/auth/authInterceptor.ts
@@ -40,7 +40,10 @@ async function performTokenRefresh(): Promise<string | null> {
   if (refreshPromise) return refreshPromise;
 
   const refreshToken = getRefreshToken();
-  if (!refreshToken) return null;
+  if (!refreshToken) {
+    console.warn('[AuthInterceptor] No refresh token available');
+    return null;
+  }
 
   refreshPromise = withTimeout(
     (async () => {
@@ -59,7 +62,10 @@ async function performTokenRefresh(): Promise<string | null> {
 
         if (isAdminRole) {
           const res = await requestRefresh({ body: { refreshToken }, throwOnError: false });
-          if (res.error || !res.data) return null;
+          if (res.error || !res.data) {
+            console.error('[AuthInterceptor] Token refresh failed:', res.error);
+            return null;
+          }
           const data = res.data as { accessToken?: string };
           if (data.accessToken) {
             setAccessToken(data.accessToken);
@@ -74,29 +80,42 @@ async function performTokenRefresh(): Promise<string | null> {
           body: { refreshToken, deviceId },
           throwOnError: false,
         });
-        if (res1.error || !res1.data) return null;
+        if (res1.error || !res1.data) {
+          console.error('[AuthInterceptor] Token refresh failed:', res1.error);
+          return null;
+        }
 
         const { nonce } = res1.data as { nonce?: string };
-        if (!nonce) return null;
+        if (!nonce) {
+          console.error('[AuthInterceptor] No nonce received');
+          return null;
+        }
 
         const signedNonce = await signNonce(nonce);
         const res2 = await verifyRefresh({
           body: { refreshToken, deviceId, signedNonce },
           throwOnError: false,
         });
-        if (res2.error || !res2.data) return null;
+        if (res2.error || !res2.data) {
+          console.error('[AuthInterceptor] Token refresh verification failed:', res2.error);
+          return null;
+        }
 
         const { accessToken, refreshToken: nextRT } = res2.data as {
           accessToken?: string;
           refreshToken?: string;
         };
-        if (!accessToken) return null;
+        if (!accessToken) {
+          console.error('[AuthInterceptor] No access token received');
+          return null;
+        }
 
         setAccessToken(accessToken);
         if (nextRT) setRefreshToken(nextRT);
         return accessToken;
-      } catch {
+      } catch (error) {
         // Network error, backend down, etc. — return null but don't logout
+        console.error('[AuthInterceptor] Token refresh exception:', error);
         return null;
       } finally {
         refreshPromise = null;
@@ -134,7 +153,9 @@ export function setupAuthInterceptors(
     if (response.status !== 401) return response;
 
     // Unauthenticated request (e.g. login) — not a session issue
-    if (!getAccessToken()) return response;
+    if (!getAccessToken()) {
+      return response;
+    }
 
     // Check if this is a refresh endpoint returning 401
     // That means the refresh token itself was rejected (session revoked by admin)
@@ -146,7 +167,7 @@ export function setupAuthInterceptors(
           const body = await response.clone().json();
           const msg = body?.message?.toLowerCase() || '';
           if (msg.includes('invalid') || msg.includes('expired') || msg.includes('revoked')) {
-            console.warn('AuthInterceptor: refresh token rejected — session revoked by admin');
+            console.warn('[AuthInterceptor] Refresh token rejected — session revoked by admin');
             options.onSessionExpired?.();
           }
         } catch {
@@ -159,7 +180,9 @@ export function setupAuthInterceptors(
     }
 
     // Prevent infinite retry loop
-    if (request.headers.get(RETRY_HEADER)) return response;
+    if (request.headers.get(RETRY_HEADER)) {
+      return response;
+    }
 
     // Try to refresh the access token silently
     const newToken = await performTokenRefresh();
@@ -176,7 +199,7 @@ export function setupAuthInterceptors(
           msg.includes('session terminated') ||
           msg.includes('device is not active')
         ) {
-          console.warn('AuthInterceptor: explicit session end signal:', body.message);
+          console.warn('[AuthInterceptor] Session terminated:', body.message);
           options.onSessionExpired?.();
         }
         // For all other failures (network errors, backend down), keep the session

--- a/frontend/src/services/auth/tokenManager.ts
+++ b/frontend/src/services/auth/tokenManager.ts
@@ -3,25 +3,20 @@
  *
  * Centralized access and refresh token storage.
  * Uses localStorage for persistence across page reloads.
- * Consumed by the auth interceptor and AuthContext.
  */
 
 const ACCESS_TOKEN_KEY = 'iviss_access_token';
 const REFRESH_TOKEN_KEY = 'iviss_refresh_token';
 const SESSION_KEY = 'iviss_session';
 
-/**
- * Retrieve the stored access token.
- */
+// Event to notify AuthContext when tokens are refreshed
+const TOKEN_REFRESHED_EVENT = 'iviss:token-refreshed';
+
 export function getAccessToken(): string | null {
   return localStorage.getItem(ACCESS_TOKEN_KEY);
 }
 
-/**
- * Store a new access token and sync it into the session object so
- * page reloads pick up the refreshed token instead of the expired one.
- */
-export function setAccessToken(token: string): void {
+export function setAccessToken(token: string, notifyContext = true): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, token);
   // Keep the session object in sync so initIdentity on next page load
   // sees a valid token and doesn't clear the session prematurely.
@@ -31,33 +26,42 @@ export function setAccessToken(token: string): void {
       const session = JSON.parse(raw);
       session.accessToken = token;
       localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+      
+      // Notify AuthContext to update its state with the new token
+      if (notifyContext) {
+        window.dispatchEvent(new CustomEvent(TOKEN_REFRESHED_EVENT, { 
+          detail: { accessToken: token, session } 
+        }));
+      }
     }
   } catch {
     // ignore
   }
 }
 
-/**
- * Retrieve the stored refresh token.
- */
 export function getRefreshToken(): string | null {
   return localStorage.getItem(REFRESH_TOKEN_KEY);
 }
 
-/**
- * Store a new refresh token.
- */
 export function setRefreshToken(token: string): void {
   localStorage.setItem(REFRESH_TOKEN_KEY, token);
+  // Keep the session object in sync
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (raw) {
+      const session = JSON.parse(raw);
+      session.refreshToken = token;
+      localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+    }
+  } catch {
+    // ignore
+  }
 }
 
 export function clearAccessToken(): void {
   localStorage.removeItem(ACCESS_TOKEN_KEY);
 }
 
-/**
- * Clear both tokens. Used on logout or when refresh fails.
- */
 export function clearTokens(): void {
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN_KEY);

--- a/frontend/src/services/auth/tokenManager.ts
+++ b/frontend/src/services/auth/tokenManager.ts
@@ -26,12 +26,14 @@ export function setAccessToken(token: string, notifyContext = true): void {
       const session = JSON.parse(raw);
       session.accessToken = token;
       localStorage.setItem(SESSION_KEY, JSON.stringify(session));
-      
+
       // Notify AuthContext to update its state with the new token
       if (notifyContext) {
-        window.dispatchEvent(new CustomEvent(TOKEN_REFRESHED_EVENT, { 
-          detail: { accessToken: token, session } 
-        }));
+        window.dispatchEvent(
+          new CustomEvent(TOKEN_REFRESHED_EVENT, {
+            detail: { accessToken: token, session },
+          })
+        );
       }
     }
   } catch {

--- a/iviss-backend/Cargo.lock
+++ b/iviss-backend/Cargo.lock
@@ -3343,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/iviss-backend/Cargo.toml
+++ b/iviss-backend/Cargo.toml
@@ -50,8 +50,8 @@ base64 = "0.22.1"
 p256 = { version = "0.13", features = ["ecdsa", "jwk"] }
 ecdsa = { version = "0.16", features = ["verifying"] }
 moka = { version = "0.12.15", features = ["future"] }
-# Force rustls-webpki to a patched version to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099
-rustls-webpki = "0.103.12"
+# Force rustls-webpki to a patched version to fix RUSTSEC-2026-0104
+rustls-webpki = "0.103.13"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder", "pool"] }
 
 [dev-dependencies]

--- a/iviss-backend/src/config.rs
+++ b/iviss-backend/src/config.rs
@@ -312,6 +312,14 @@ impl Config {
         }
         // Validate SMS provider config in production
         if self.environment == Environment::Production {
+            // Mock SMS provider is not allowed in production
+            if matches!(&self.sms_credentials, SmsProviderCredentials::Mock) {
+                return Err(anyhow!(
+                    "Mock SMS provider is not allowed in production environment"
+                ));
+            }
+            
+            // Validate Orange credentials if using Orange provider
             if matches!(
                 &self.sms_credentials,
                 SmsProviderCredentials::Orange {

--- a/iviss-backend/src/config.rs
+++ b/iviss-backend/src/config.rs
@@ -318,7 +318,6 @@ impl Config {
                     "Mock SMS provider is not allowed in production environment"
                 ));
             }
-            
             // Validate Orange credentials if using Orange provider
             if matches!(
                 &self.sms_credentials,

--- a/iviss-backend/src/services/jwt_service.rs
+++ b/iviss-backend/src/services/jwt_service.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-const ACCESS_TOKEN_TTL: Duration = Duration::from_secs(5 * 60);
+const ACCESS_TOKEN_TTL: Duration = Duration::from_secs(15 * 60);
 const SHIFT_TTL: Duration = Duration::from_secs(8 * 60 * 60);
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- Modified the error handling to skip 401 errors entirely, allowing the auth interceptor to handle them. Generic 401 errors mean "token expired" and should trigger a refresh, not a logout. Only explicit `SESSION_REVOKED` codes should log users out.
- Corrected the session object structure to use accessToken consistently.
- Implemented Event-Based State Synchronization between the Interceptor and AuthContext React State. When the interceptor refreshes a token, the AuthContext React state is immediately updated, keeping the UI in sync without requiring a page reload.
- Enhanced Auth Interceptor Logic and Session Persistence Across Page Reloads
- Increased access token duration from 1 minute to 15 minutes