### PR TITLE
fix: trigger pipeline on push to main instead of pull_request

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,19 +1,14 @@
 name: Unified Release & Docker Pipeline
 
 on:
-  # Triggered when a PR targeting main is closed (merged or declined)
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
   workflow_dispatch:
 
 jobs:
   release:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Determine Release Version
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Semantic-release refuses to publish on pull_request events. Using push to main ensures semantic-release runs after the merge is complete and can properly determine the next version.