### PR TITLE
feat(observability): add Prometheus metrics and OpenTelemetry distrib…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,7 @@ GITHUB_TOKEN=your-github-personal-access-token
 DOMAIN_NAME=iviss.example.com
 CERTBOT_EMAIL=admin@example.com
 DB_PASSWORD=randomly-generated-if-left-empty
+
+# --- Observability (OpenTelemetry) ---
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=iviss-backend

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,131 +1,131 @@
-# IVISS Monitoring Stack
+# IVISS Observability
 
-Prometheus + Grafana observability for the IVISS frontend.
+Prometheus metrics, OpenTelemetry distributed tracing, and structured logging.
 
 ## Architecture
 
 ```
-Browser (React SPA)
+iviss-api pod
     │
-    │  POST /api/metrics (every 10s)
-    ▼
-┌─────────────────────┐
-│  Metrics Server     │ :9091
-│  (Node.js/Express)  │
-│  GET /metrics       │
-└────────┬────────────┘
-         │  Scrape (every 10s)
-         ▼
-┌─────────────────────┐
-│    Prometheus       │ :9090
-│  (Time-series DB)   │
-└────────┬────────────┘
-         │  Query
-         ▼
-┌─────────────────────┐
-│     Grafana         │ :3001
-│   (Dashboards)      │
-└─────────────────────┘
+    ├── /metrics  (Prometheus exporter, port 3000)
+    │       │
+    │       ▼
+    │   kube-prometheus-stack ServiceMonitor
+    │       │
+    │       ▼
+    │   Prometheus  ──►  Grafana dashboards + alert rules
+    │
+    └── OTLP/HTTP (port 4318)
+            │
+            ▼
+        Alloy (logging ns)  ──►  Tempo  ──►  Grafana (traces → logs → metrics correlation)
 ```
 
-## Quick Start
+## Backend Telemetry (`src/telemetry.rs`)
 
-```bash
-# From the project root — starts everything (including monitoring)
-docker compose up -d
+The backend initializes two telemetry subsystems at startup:
 
-# Check all services are running
-docker compose ps
+### Prometheus Metrics
+
+Exposed at `GET /metrics` via `metrics-exporter-prometheus` (port 3000, same as the API server).
+
+**Custom metrics registered in `init_metrics()`:**
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `iviss_http_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests |
+| `iviss_http_request_duration_seconds` | Histogram | `method`, `path` | Request latency buckets |
+| `iviss_auth_attempts_total` | Counter | `method` | Login/activation attempts |
+| `iviss_auth_failures_total` | Counter | `reason` | Authentication failures |
+| `iviss_scans_total` | Counter | `plate_length` | Successful plate scans |
+| `iviss_scan_errors_total` | Counter | `error_type` | Scan/OCR failures |
+| `iviss_active_sessions` | Gauge | — | Current authenticated sessions |
+
+### Distributed Tracing
+
+OpenTelemetry traces are exported via OTLP/HTTP to Grafana Alloy:
+
+- **Endpoint**: `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://alloy.logging.svc.cluster.local:4318`)
+- **Service name**: `OTEL_SERVICE_NAME` (default: `iviss-backend`)
+- **Transport**: HTTP (matches Alloy's `otelcol.receiver.otlp` HTTP receiver)
+
+Instrumented handlers (via `#[instrument]`):
+
+| Handler | Span name |
+|---------|-----------|
+| `auth.login` | `auth::login` |
+| `auth.activate` | `auth::activate` |
+| `scan.plate` | `scan::plate` |
+| `photo.plate` | `photo::plate` |
+| `vehicle.search` | `vehicle::search` |
+| `vehicle.search_v1` | `vehicle::search_v1` |
+| `control.create` | `control::create` |
+| `health.check` | `health::check` |
+
+### Structured Logging
+
+Uses `tracing_subscriber` with a layered format:
+- **Layer 1**: `fmt` (stdout, for `kubectl logs`)
+- **Layer 2**: OpenTelemetry (for Tempo)
+
+Both layers are initialized at startup. If OTel provider init fails, the app still starts with just fmt logging (graceful degradation).
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Not set (tracing disabled) | Alloy OTLP HTTP endpoint |
+| `OTEL_SERVICE_NAME` | `iviss-backend` | Service name in traces |
+| `LOG_LEVEL` | `info` | Log level for fmt subscriber |
+
+## Graceful Shutdown
+
+`TelemetryHandle::shutdown()` is called on SIGTERM/SIGINT:
+1. Flushes all pending OTel spans to Alloy (via `tracer_provider.shutdown()`)
+2. Drops the Prometheus exporter
+
+## Adding New Metrics
+
+1. Register the metric in `src/telemetry.rs::init_metrics()`
+2. Use it in handlers via `metrics::counter!()`, `metrics::histogram!()`, or `metrics::gauge!()`
+3. Add panels to the Grafana dashboard (`monitoring/grafana/dashboards/iviss-backend-dashboard.yaml` in the OM repo)
+
+## Adding Tracing to a Handler
+
+```rust
+#[tracing::instrument]
+async fn my_handler(State(state): State<AppState>) -> impl IntoResponse {
+    // ...
+}
 ```
 
-## Access
+No additional imports needed — `tracing::instrument` is already in scope.
 
-| Service            | Precise URL                                                                | Credentials       |
-| ------------------ | -------------------------------------------------------------------------- | ----------------- |
-| **Frontend**       | [http://localhost:8080/](http://localhost:8080/)                           | —                 |
-| **Grafana**        | [http://localhost:3001/login](http://localhost:3001/login)                 | `admin` / `admin` |
-| **Prometheus**     | [http://localhost:9090/targets](http://localhost:9090/targets)             | —                 |
-| **Metrics Data**   | [http://localhost:9091/metrics](http://localhost:9091/metrics)             | —                 |
-| **Backend Health** | [http://localhost:3000/api/v1/health](http://localhost:3000/api/v1/health) | —                 |
+## Scrape Configuration
 
-## Verification Steps
+The backend is scraped by `kube-prometheus-stack` via a `ServiceMonitor` (enabled in Helm values):
 
-1. **Start the stack:**
+```yaml
+metrics:
+  enabled: true
+  port: 3000
+  path: /metrics
 
-   ```bash
-   docker compose up -d
-   ```
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+```
 
-2. **Generate Traffic:**
-   - Open **Frontend** at [http://localhost:8080/](http://localhost:8080/)
-   - Navigate to different pages to generate data.
+This is configured in `helm/values/iviss/api.yaml` in the OM repo.
 
-3. **Check Status:**
-   - **Prometheus**: Go to [http://localhost:9090/targets](http://localhost:9090/targets) -> Ensure `frontend-metrics` is **UP**.
-   - **Grafana**: Go to [http://localhost:3001/](http://localhost:3001/) -> `admin`/`admin` -> **Dashboards** -> **IVISS Frontend Monitoring**.
-   - **Metrics**: Go to [http://localhost:9091/metrics](http://localhost:9091/metrics) -> Should see raw text data.
+## Correlation
 
-A pre-built **"IVISS Frontend Monitoring"** dashboard is auto-provisioned with:
+In Grafana, traces are correlated to logs and metrics:
+- **Traces → Logs**: Trace ID injected into log lines, searchable in Loki
+- **Traces → Metrics**: Span metrics generated by Tempo
+- **Logs → Traces**: `trace_id` label extracted by Alloy's `loki.process` stage
 
-| Panel                    | Description                          |
-| ------------------------ | ------------------------------------ |
-| Frontend Availability    | UP/DOWN heartbeat status             |
-| Active Sessions          | Concurrent browser sessions          |
-| Total Errors             | Cumulative JS error count            |
-| Route Navigations        | Client-side navigation count         |
-| Page Load Duration       | Load time over time                  |
-| Errors Over Time         | Error rate (per minute)              |
-| LCP Gauge                | Largest Contentful Paint (Web Vital) |
-| FID Gauge                | First Input Delay (Web Vital)        |
-| CLS Gauge                | Cumulative Layout Shift (Web Vital)  |
-| Route Navigations / Time | Navigation rate over time            |
-| Active Sessions / Time   | Session count over time              |
-
-## Collected Metrics
-
-| Metric                             | Type      | Source                                  |
-| ---------------------------------- | --------- | --------------------------------------- |
-| `frontend_up`                      | Gauge     | Heartbeat from active sessions          |
-| `frontend_active_sessions`         | Gauge     | Concurrent browser sessions             |
-| `frontend_page_load_duration_ms`   | Histogram | Navigation Timing API                   |
-| `frontend_lcp_ms`                  | Gauge     | PerformanceObserver                     |
-| `frontend_fid_ms`                  | Gauge     | PerformanceObserver                     |
-| `frontend_cls`                     | Gauge     | PerformanceObserver                     |
-| `frontend_route_navigations_total` | Counter   | React Router location changes           |
-| `frontend_errors_total`            | Counter   | `window.onerror` + `unhandledrejection` |
-
-## Configuration
-
-### Environment Variables
-
-**Root `.env`:**
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GRAFANA_ADMIN_USER` | `admin` | Grafana login username |
-| `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana login password |
-| `PROMETHEUS_RETENTION` | `15d` | How long Prometheus keeps metrics |
-
-**Frontend `.env`:**
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `VITE_METRICS_ENABLED` | `true` | Enable/disable browser metrics collection |
-| `VITE_METRICS_URL` | `http://localhost:9091/api/metrics` | Metrics server endpoint |
-
-### Disabling Metrics
-
-Set `VITE_METRICS_ENABLED=false` in `frontend/.env` to disable browser-side metrics collection without removing any code.
-
-## Adding Custom Metrics
-
-1. Define new metrics in `frontend/metrics-server.js` using `prom-client`
-2. Send them from the browser via `frontend/src/services/metricsCollector.ts`
-3. Add panels to the Grafana dashboard in `monitoring/grafana/dashboards/frontend-dashboard.json`
-
-## Troubleshooting
-
-| Issue                           | Solution                                                                         |
-| ------------------------------- | -------------------------------------------------------------------------------- |
-| Prometheus shows target as DOWN | Check `docker compose logs metrics-server`                                       |
-| No data in Grafana              | Open the frontend in a browser and wait ~15s                                     |
-| Grafana can't reach Prometheus  | Ensure both are on `iviss-network`: `docker network inspect iviss_iviss-network` |
-| Metrics not updating            | Check browser console for fetch errors to `/api/metrics`                         |
+Query example in Grafana Explore:
+- Search logs for a trace: `{app="iviss-backend"} |= "trace_id=abc123"`
+- Jump from a trace span to related logs via the "Logs for this span" link

--- a/iviss-backend/Cargo.lock
+++ b/iviss-backend/Cargo.lock
@@ -180,6 +180,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,7 +329,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1585,10 +1607,24 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1608,7 +1644,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1908,9 +1944,15 @@ dependencies = [
  "jsonwebtoken",
  "leptess",
  "lettre",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mockito",
  "moka",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "p256",
  "rand 0.8.6",
  "regex",
@@ -1927,9 +1969,10 @@ dependencies = [
  "time",
  "tokio",
  "tokio-test",
- "tower",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "urlencoding",
  "utoipa",
@@ -2067,7 +2110,7 @@ dependencies = [
  "percent-encoding",
  "quoted_printable",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-rustls",
  "url",
@@ -2226,6 +2269,53 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.14.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -2548,6 +2638,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.6",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +2913,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,6 +3095,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +3130,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2931,7 +3166,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2968,7 +3203,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3070,6 +3305,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,6 +3370,15 @@ dependencies = [
  "rav1e",
  "rayon",
  "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3251,7 +3513,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
@@ -3411,6 +3673,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3457,6 +3720,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -3813,6 +4077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +4095,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4355,7 +4635,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4503,6 +4783,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4557,7 +4887,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -4620,6 +4950,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,12 +4987,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/iviss-backend/Cargo.toml
+++ b/iviss-backend/Cargo.toml
@@ -19,10 +19,21 @@ serde_json = "1"
 dotenvy = "0.15"
 config = "0.14"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower-http = { version = "0.5", features = ["cors", "trace", "fs", "compression-gzip", "timeout"] }
 anyhow = "1.0"
 thiserror = "1.0"
+
+# Observability - Metrics (Prometheus)
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
+
+# Observability - Distributed Tracing (OpenTelemetry)
+opentelemetry = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-client"] }
+tracing-opentelemetry = "0.28"
+opentelemetry-semantic-conventions = "0.27"
 
 utoipa = { version = "4", features = ["axum_extras", "uuid", "time"] }
 utoipa-swagger-ui = { version = "7", features = ["axum", "vendored"] }

--- a/iviss-backend/src/handlers/auth.rs
+++ b/iviss-backend/src/handlers/auth.rs
@@ -10,6 +10,7 @@ use axum::extract::{Extension, State};
 use axum::http::header::AUTHORIZATION;
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use base64::Engine;
+use tracing::instrument;
 
 use crate::dto::users::{UserProfile, UserRole, UserStatus};
 use crate::errors::AppError;
@@ -50,6 +51,7 @@ pub async fn on_shift_ended(pool: &sqlx::PgPool, device_id: Uuid) -> AppError {
     tag = "auth",
     operation_id = "loginUser"
 )]
+#[instrument(name = "auth.login", skip(state, payload), fields(email = %payload.email))]
 pub async fn login(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<LoginRequest>,
@@ -285,6 +287,7 @@ async fn revoke_all_user_refresh_tokens(
     tag = "auth",
     operation_id = "activateDevice"
 )]
+#[instrument(name = "auth.activate", skip(state, payload), fields(badge_id = %payload.badge_id))]
 pub async fn activate(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<ActivateRequest>,

--- a/iviss-backend/src/handlers/health.rs
+++ b/iviss-backend/src/handlers/health.rs
@@ -1,4 +1,5 @@
 use axum::{http::StatusCode, response::IntoResponse};
+use tracing::instrument;
 
 #[utoipa::path(
     get,
@@ -9,6 +10,7 @@ use axum::{http::StatusCode, response::IntoResponse};
         (status = 200, description = "Service is healthy", body = String)
     )
 )]
+#[instrument(name = "health.check")]
 pub async fn health_check() -> impl IntoResponse {
     (StatusCode::OK, "OK")
 }

--- a/iviss-backend/src/handlers/list_control.rs
+++ b/iviss-backend/src/handlers/list_control.rs
@@ -5,6 +5,7 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
+use tracing::instrument;
 
 use crate::{
     app_state::AppState,
@@ -29,6 +30,7 @@ use crate::{
     ),
     security(("bearer_auth" = []))
 )]
+#[instrument(name = "control.create", skip(state, payload))]
 pub async fn create_control(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<CreateControlRequest>,

--- a/iviss-backend/src/handlers/photo.rs
+++ b/iviss-backend/src/handlers/photo.rs
@@ -1,4 +1,5 @@
 use axum::{extract::Multipart, http::StatusCode, response::IntoResponse, Json};
+use tracing::instrument;
 
 #[allow(unused_imports)]
 use crate::dto::scan::ImageUploadRequest;
@@ -33,6 +34,7 @@ const OCR_TIMEOUT_MS: u64 = 9000;
         (status = 500, description = "Internal OCR error",               body = ScanPlateResponse),
     ),
 )]
+#[instrument(name = "photo.plate", skip(multipart))]
 pub async fn photo_plate(mut multipart: Multipart) -> impl IntoResponse {
     let (content_type, image_bytes) = match extract_image_field(&mut multipart).await {
         Ok(v) => v,

--- a/iviss-backend/src/handlers/scan.rs
+++ b/iviss-backend/src/handlers/scan.rs
@@ -1,4 +1,5 @@
 use axum::{extract::Multipart, http::StatusCode, response::IntoResponse, Json};
+use tracing::instrument;
 
 #[allow(unused_imports)]
 use crate::dto::scan::ImageUploadRequest;
@@ -33,6 +34,7 @@ const OCR_TIMEOUT_MS: u64 = 9000;
         (status = 500, description = "Internal OCR error",                  body = ScanPlateResponse),
     ),
 )]
+#[instrument(name = "scan.plate", skip(multipart))]
 pub async fn scan_plate(mut multipart: Multipart) -> impl IntoResponse {
     // ── 1. Extract the `image` field from the multipart body ─────────────────
     let (content_type, image_bytes) = match extract_image_field(&mut multipart).await {

--- a/iviss-backend/src/handlers/search_vehicle.rs
+++ b/iviss-backend/src/handlers/search_vehicle.rs
@@ -16,6 +16,7 @@ use axum::{
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::sync::Arc;
+use tracing::instrument;
 use uuid::Uuid;
 
 // ── POST /api/v1/vehicles/search ──────────────────────────────────────────────
@@ -39,6 +40,7 @@ use uuid::Uuid;
     ),
     security(("bearer_auth" = []))
 )]
+#[instrument(name = "vehicle.search", skip(state, payload), fields(plate = %payload.plate))]
 pub async fn search_vehicle(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<VehicleSearchRequest>,
@@ -154,6 +156,7 @@ pub async fn search_vehicle(
     ),
     security(("bearer_auth" = []))
 )]
+#[instrument(name = "vehicle.search_v1", skip(state, payload), fields(plate = %payload.plate))]
 pub async fn search_vehicle_v1(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<VehicleSearchRequest>,

--- a/iviss-backend/src/lib.rs
+++ b/iviss-backend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod models;
 pub mod queries;
 pub mod routes;
 pub mod services;
+pub mod telemetry;
 #[cfg(test)]
 pub mod tests;
 pub mod utils;

--- a/iviss-backend/src/main.rs
+++ b/iviss-backend/src/main.rs
@@ -5,10 +5,10 @@ use iviss_backend::app_state::AppState;
 use iviss_backend::config::Config;
 use iviss_backend::db::initialize_pool;
 use iviss_backend::db::seed_admin::run_bootstrap_seed;
-// use iviss_backend::db::seed_data::run_seed_data;
 use iviss_backend::routes;
 use iviss_backend::services::email_provider::EmailProvider;
 use iviss_backend::services::sms_provider::SmsProvider;
+use iviss_backend::telemetry;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::info;
@@ -17,19 +17,14 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Load configuration first (fail-fast if config is invalid)
     let config = Config::from_env().context("Failed to load configuration")?;
 
-    // Validate configuration
     config
         .validate()
         .context("Configuration validation failed")?;
-    // Initialize logging based on configuration
-    tracing_subscriber::fmt()
-        .with_target(false)
-        .with_max_level(config.log_level.as_tracing_level())
-        .compact()
-        .init();
+
+    let telemetry_handle =
+        Arc::new(telemetry::init_telemetry(&config.log_level).context("Failed to init telemetry")?);
 
     info!("Starting IVISS Backend...");
     info!("Environment: {:?}", config.environment);
@@ -51,22 +46,41 @@ async fn main() -> anyhow::Result<()> {
     info!("Running admin bootstrap seed...");
     run_bootstrap_seed(&db_pool, &config).await;
 
-    // info!("Running seed data...");
-    // run_seed_data(&db_pool).await;
-
     info!("Caching necessary data from database...");
     cache.cache_necessary_data_from_database(&db_pool).await?;
 
     let state = AppState::new(db_pool, cache, sms_provider, email_provider, &config)
         .context("Failed to initialize application state")?;
+
+    let metrics_handle = telemetry_handle.clone();
+
     let app = routes::assembly(state)
-        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", ApiDoc::openapi()));
+        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", ApiDoc::openapi()))
+        .route(
+            "/metrics",
+            axum::routing::get(move || telemetry::metrics_handler(metrics_handle)),
+        );
 
     let addr: SocketAddr = format!("{}:{}", config.server_host, config.server_port).parse()?;
     info!("Listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+
+    let shutdown_handle = telemetry_handle.clone();
+    let shutdown = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+        info!("Shutdown signal received, flushing telemetry...");
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await?;
+
+    info!("Shutting down...");
+    shutdown_handle.shutdown();
+    info!("Telemetry flushed. Goodbye.");
 
     Ok(())
 }

--- a/iviss-backend/src/middleware/auth.rs
+++ b/iviss-backend/src/middleware/auth.rs
@@ -197,7 +197,7 @@ pub fn decode_access_token_rs256(
     let raw_pem = if !cleaned.starts_with("-----") {
         match base64::Engine::decode(
             &base64::prelude::BASE64_STANDARD,
-            cleaned.replace("\\n", "").replace("\n", "").trim()
+            cleaned.replace("\\n", "").replace("\n", "").trim(),
         ) {
             Ok(decoded) => String::from_utf8(decoded).unwrap_or_else(|_| cleaned.to_string()),
             Err(_) => cleaned.to_string(),

--- a/iviss-backend/src/telemetry.rs
+++ b/iviss-backend/src/telemetry.rs
@@ -1,0 +1,129 @@
+use anyhow::Result;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_sdk::Resource;
+use std::sync::Arc;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+pub struct TelemetryHandle {
+    pub metrics_recorder: Arc<metrics_exporter_prometheus::PrometheusHandle>,
+    tracer_provider: Option<TracerProvider>,
+}
+
+impl TelemetryHandle {
+    pub fn metrics_output(&self) -> String {
+        self.metrics_recorder.render()
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(tp) = &self.tracer_provider {
+            if let Err(e) = tp.shutdown() {
+                tracing::error!("error shutting down tracer provider: {e}");
+            }
+        }
+    }
+}
+
+pub fn init_telemetry(log_level: &crate::config::LogLevel) -> Result<TelemetryHandle> {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(log_level.as_tracing_level().to_string()));
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .compact();
+
+    let (tracer_provider, otel_layer) = match init_tracer_provider() {
+        Ok(provider) => {
+            let tracer = provider.tracer("iviss-backend");
+            let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+            (Some(provider), Some(layer))
+        }
+        Err(e) => {
+            eprintln!("OTel tracer init failed (traces disabled): {e}");
+            (None, None)
+        }
+    };
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer);
+
+    match otel_layer {
+        Some(layer) => registry.with(layer).init(),
+        None => registry.init(),
+    }
+
+    let metrics_handle = init_metrics()?;
+
+    let handle = TelemetryHandle {
+        metrics_recorder: Arc::new(metrics_handle),
+        tracer_provider,
+    };
+
+    tracing::info!("Telemetry initialized (metrics + tracing)");
+
+    Ok(handle)
+}
+
+fn init_tracer_provider() -> Result<TracerProvider> {
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4318".to_string());
+
+    let service_name =
+        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "iviss-backend".to_string());
+
+    let resource = Resource::new(vec![
+        opentelemetry::KeyValue::new("service.name", service_name),
+        opentelemetry::KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+    ]);
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(&otlp_endpoint)
+        .build()?;
+
+    let tracer_provider = TracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .build();
+
+    Ok(tracer_provider)
+}
+
+fn init_metrics() -> Result<metrics_exporter_prometheus::PrometheusHandle> {
+    let handle = PrometheusBuilder::new()
+        .set_quantiles(&[0.5, 0.9, 0.95, 0.99])?
+        .install_recorder()?;
+
+    metrics::describe_counter!("iviss_http_requests_total", "Total number of HTTP requests");
+    metrics::describe_histogram!(
+        "iviss_http_request_duration_seconds",
+        "HTTP request duration in seconds"
+    );
+    metrics::describe_gauge!("iviss_active_sessions", "Number of active sessions");
+    metrics::describe_counter!("iviss_scans_total", "Total number of plate scans");
+    metrics::describe_counter!("iviss_scan_errors_total", "Total number of scan errors");
+    metrics::describe_counter!(
+        "iviss_auth_attempts_total",
+        "Total number of authentication attempts"
+    );
+    metrics::describe_counter!(
+        "iviss_auth_failures_total",
+        "Total number of authentication failures"
+    );
+
+    Ok(handle)
+}
+
+pub async fn metrics_handler(handle: Arc<TelemetryHandle>) -> impl axum::response::IntoResponse {
+    (
+        axum::http::StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        handle.metrics_output(),
+    )
+}


### PR DESCRIPTION
…uted tracing

- Add telemetry module with Prometheus exporter and OTLP trace provider
- Expose /metrics endpoint for Prometheus scraping
- Add #[instrument] to auth, scan, photo, search_vehicle, list_control, health handlers
- Configure layered tracing subscriber (fmt + OTel)
- Add graceful shutdown with telemetry flush
- Add OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME to .env.example