### PR TITLE
feat(observability): serve metrics on internal port 9091

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -7,13 +7,17 @@ Prometheus metrics, OpenTelemetry distributed tracing, and structured logging.
 ```
 iviss-api pod
     │
-    ├── /metrics  (Prometheus exporter, port 3000)
-    │       │
-    │       ▼
-    │   kube-prometheus-stack ServiceMonitor
-    │       │
-    │       ▼
-    │   Prometheus  ──►  Grafana dashboards + alert rules
+    ├── :3000  (API server — public, via ingress)
+    │       └── metrics middleware records iviss_http_requests_total/duration on every request
+    │
+    ├── :9091  (metrics server — internal-only, NOT exposed via ingress)
+    │       └── GET /metrics → Prometheus scrape endpoint
+    │               │
+    │               ▼
+    │           kube-prometheus-stack ServiceMonitor
+    │               │
+    │               ▼
+    │           Prometheus  ──►  Grafana dashboards + alert rules
     │
     └── OTLP/HTTP (port 4318)
             │
@@ -27,7 +31,10 @@ The backend initializes two telemetry subsystems at startup:
 
 ### Prometheus Metrics
 
-Exposed at `GET /metrics` via `metrics-exporter-prometheus` (port 3000, same as the API server).
+Served on a **separate internal port (9091)** so that `/metrics` is only accessible
+from within the cluster (via ServiceMonitor), **not** through the public ingress.
+The metrics middleware (`src/middleware/metrics.rs`) records `iviss_http_requests_total`
+and `iviss_http_request_duration_seconds` on every HTTP request on the main API port (3000).
 
 **Custom metrics registered in `init_metrics()`:**
 
@@ -103,12 +110,15 @@ No additional imports needed — `tracing::instrument` is already in scope.
 
 ## Scrape Configuration
 
-The backend is scraped by `kube-prometheus-stack` via a `ServiceMonitor` (enabled in Helm values):
+The backend exposes `/metrics` on port **9091** (separate from the API on port 3000).
+This ensures metrics are only accessible from within the cluster, not through the public ingress.
+
+The ServiceMonitor scrapes on port 9091:
 
 ```yaml
 metrics:
   enabled: true
-  port: 3000
+  port: 9091
   path: /metrics
 
 serviceMonitor:

--- a/iviss-backend/.env.example
+++ b/iviss-backend/.env.example
@@ -24,6 +24,10 @@ SERVER_PORT=3000
 # Options: trace, debug, info, warn, error
 LOG_LEVEL=info
 
+# Observability Configuration
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=iviss-backend
+
 # Environment
 # Options: local, staging, production
 ENVIRONMENT=local

--- a/iviss-backend/src/main.rs
+++ b/iviss-backend/src/main.rs
@@ -59,13 +59,21 @@ async fn main() -> anyhow::Result<()> {
     )
     .context("Failed to initialize application state")?;
 
-    let app = routes::assembly(state)
+    let shared_state = Arc::new(state);
+
+    let app = routes::assembly((*shared_state).clone())
         .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", ApiDoc::openapi()));
+
+    let metrics_app = routes::metrics_router(shared_state.clone());
 
     let addr: SocketAddr = format!("{}:{}", config.server_host, config.server_port).parse()?;
     info!("Listening on {}", addr);
 
+    let metrics_addr: SocketAddr = format!("{}:9091", config.server_host).parse()?;
+    info!("Metrics listening on {}", metrics_addr);
+
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    let metrics_listener = tokio::net::TcpListener::bind(metrics_addr).await?;
 
     let shutdown = async {
         tokio::signal::ctrl_c()
@@ -74,9 +82,11 @@ async fn main() -> anyhow::Result<()> {
         info!("Shutdown signal received, draining...");
     };
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown)
-        .await?;
+    // Run both servers concurrently; either shutdown or error stops both.
+    tokio::select! {
+        r = axum::serve(listener, app).with_graceful_shutdown(shutdown) => r?,
+        r = axum::serve(metrics_listener, metrics_app) => r?,
+    };
 
     // Flush telemetry while the Tokio runtime is still active.
     telemetry_handle.shutdown().await;

--- a/iviss-backend/src/routes.rs
+++ b/iviss-backend/src/routes.rs
@@ -193,10 +193,18 @@ pub fn assembly(state: AppState) -> Router {
         .merge(org_admin_routes)
         .merge(web_auth_routes)
         .merge(protected_routes)
-        .route("/metrics", get(crate::handlers::health::metrics_export))
         .layer(axum::middleware::from_fn(metrics::track_metrics))
         .layer(CompressionLayer::new())
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
         .layer(cors::cors_layer())
+        .with_state(state)
+}
+
+/// Internal metrics server — served on a separate port (9091) so that
+/// /metrics is only accessible from within the cluster (Prometheus
+/// ServiceMonitor), NOT through the public ingress.
+pub fn metrics_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/metrics", get(crate::handlers::health::metrics_export))
         .with_state(state)
 }


### PR DESCRIPTION
Move /metrics off the public API port (3000) onto a dedicated internal listener on port 9091 so it's only reachable within the cluster via ServiceMonitor, not through the public ingress.

- Add metrics_router() with just GET /metrics on port 9091
- Start dual TcpListeners in main.rs via tokio::select!
- Remove /metrics from the public route tree (routes.rs)
- Re-add OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME to .env.example
- Update monitoring docs for dual-listener architecture