### PR TITLE
fix: add TelemetryHandle::noop() and pass it in all test AppState::ne…

### DIFF
--- a/iviss-backend/src/telemetry.rs
+++ b/iviss-backend/src/telemetry.rs
@@ -13,6 +13,16 @@ pub struct TelemetryHandle {
 }
 
 impl TelemetryHandle {
+    pub fn noop() -> Self {
+        let recorder = PrometheusBuilder::new()
+            .install_recorder()
+            .expect("failed to install noop metrics recorder");
+        Self {
+            metrics_recorder: Arc::new(recorder),
+            tracer_provider: None,
+        }
+    }
+
     pub fn metrics_output(&self) -> String {
         self.metrics_recorder.render()
     }

--- a/iviss-backend/src/tests/admin_login_and_refresh_token_tests.rs
+++ b/iviss-backend/src/tests/admin_login_and_refresh_token_tests.rs
@@ -1,5 +1,6 @@
 use crate::app_state::AppState;
 use crate::routes;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::json;
@@ -91,6 +92,7 @@ async fn setup_admin_login_test() -> (
         Arc::new(crate::services::sms_provider::MockSmsProvider),
         Arc::new(crate::services::email_provider::MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/admin_logout_tests.rs
+++ b/iviss-backend/src/tests/admin_logout_tests.rs
@@ -1,5 +1,6 @@
 use crate::app_state::AppState;
 use crate::routes;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::json;
@@ -94,6 +95,7 @@ async fn setup_admin_logout_test() -> (
         Arc::new(crate::services::sms_provider::MockSmsProvider),
         Arc::new(crate::services::email_provider::MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/daily_login_flow_tests.rs
+++ b/iviss-backend/src/tests/daily_login_flow_tests.rs
@@ -2,6 +2,7 @@ use crate::app_state::AppState;
 use crate::routes;
 use crate::services::otp_service::OTP_TTL_SECS;
 use crate::services::sms_provider::MockSmsProvider;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use hmac::Mac;
@@ -181,6 +182,7 @@ async fn setup_test_infrastructure() -> (
         Arc::new(MockSmsProvider),
         Arc::new(crate::services::email_provider::MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/refresh_endpoint_tests.rs
+++ b/iviss-backend/src/tests/refresh_endpoint_tests.rs
@@ -2,6 +2,7 @@ use crate::app_state::AppState;
 use crate::routes;
 use crate::services::email_provider::MockEmailProvider;
 use crate::services::sms_provider::MockSmsProvider;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::Engine;
@@ -196,6 +197,7 @@ async fn setup_test_infrastructure() -> (
         Arc::new(MockSmsProvider),
         Arc::new(MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/stats_handler_tests.rs
+++ b/iviss-backend/src/tests/stats_handler_tests.rs
@@ -10,6 +10,7 @@
 use crate::app_state::AppState;
 use crate::routes;
 use crate::services::sms_provider::MockSmsProvider;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::Engine;
@@ -71,6 +72,7 @@ async fn setup_test_app() -> (
         Arc::new(MockSmsProvider),
         Arc::new(crate::services::email_provider::MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/terminate_session_tests.rs
+++ b/iviss-backend/src/tests/terminate_session_tests.rs
@@ -1,6 +1,7 @@
 use crate::app_state::AppState;
 use crate::routes;
 use crate::services::sms_provider::MockSmsProvider;
+use crate::telemetry::TelemetryHandle;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::Engine;
@@ -82,6 +83,7 @@ async fn setup_test_app() -> (
         Arc::new(MockSmsProvider),
         Arc::new(crate::services::email_provider::MockEmailProvider),
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 

--- a/iviss-backend/src/tests/users_and_user_manager_tests.rs
+++ b/iviss-backend/src/tests/users_and_user_manager_tests.rs
@@ -19,6 +19,7 @@ use crate::{
     routes,
     services::jwt_service::JwtService,
     services::otp_service::OTP_TTL_SECS,
+    telemetry::TelemetryHandle,
 };
 
 use testcontainers_modules::{postgres::Postgres, testcontainers::runners::AsyncRunner};
@@ -152,6 +153,7 @@ async fn setup_test_app() -> (
         sms_provider,
         email_provider,
         &config,
+        Arc::new(TelemetryHandle::noop()),
     )
     .expect("failed to initialize test app state");
 


### PR DESCRIPTION


Tests were missing the 6th telemetry argument added to AppState::new(). Add a noop() constructor for use in tests that don't need real telemetry.