### PR TITLE
chore: update OM repo checkout ref to main

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: skyengpro/om
-          ref: feat/iviss-deployment
+          ref: main
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Update backend image tag


### PR DESCRIPTION
Updates the `update-om-values` job in `pipeline.yml` to checkout the `main` branch of `skyengpro/om` instead of `feat/iviss-deployment`, matching the updated ArgoCD `targetRevision` change in [skyengpro/om#152](https://github.com/skyengpro/om/pull/152).

The IVISS ArgoCD apps now point to `main`, so the CI needs to push image tag updates there too.